### PR TITLE
Improve the System Tray

### DIFF
--- a/src/Captura.Core/Captura.Core.csproj
+++ b/src/Captura.Core/Captura.Core.csproj
@@ -71,6 +71,8 @@
     <Compile Include="Models\Hotkeys\HotKeyManager.cs" />
     <Compile Include="Models\Hotkeys\HotkeyModel.cs" />
     <Compile Include="Models\Hotkeys\Modifiers.cs" />
+    <Compile Include="Models\IRegionProvider.cs" />
+    <Compile Include="Models\ISystemTray.cs" />
     <Compile Include="Models\MixedAudioProvider.cs" />
     <Compile Include="Models\MouseKeyHook\KeyRecord.cs" />
     <Compile Include="Models\MouseKeyHook\MouseKeyHook.cs" />

--- a/src/Captura.Core/Models/IRegionProvider.cs
+++ b/src/Captura.Core/Models/IRegionProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Drawing;
+
+namespace Captura.Models
+{
+    public interface IRegionProvider
+    {
+        bool SelectorVisible { get; set; }
+
+        Rectangle SelectedRegion { get; set; }
+
+        IVideoItem VideoSource { get; }
+    }
+}

--- a/src/Captura.Core/Models/ISystemTray.cs
+++ b/src/Captura.Core/Models/ISystemTray.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Captura.Models
+{
+    interface ISystemTray
+    {
+        void ShowTextNotification(string Text, string Title, int Duration, Action OnClick = null);
+
+        void ShowScreenShotNotification(string FilePath);
+
+        void HideNotification();
+    }
+}

--- a/src/Captura.Core/Models/ISystemTray.cs
+++ b/src/Captura.Core/Models/ISystemTray.cs
@@ -2,9 +2,9 @@
 
 namespace Captura.Models
 {
-    interface ISystemTray
+    public interface ISystemTray
     {
-        void ShowTextNotification(string Text, string Title, int Duration, Action OnClick = null);
+        void ShowTextNotification(string Text, int Duration, Action OnClick);
 
         void ShowScreenShotNotification(string FilePath);
 

--- a/src/Captura.Core/Models/SystemTrayManager.cs
+++ b/src/Captura.Core/Models/SystemTrayManager.cs
@@ -1,74 +1,11 @@
-﻿using System;
-using System.Drawing;
+﻿using Captura.Models;
+using System;
 using System.Windows.Forms;
 
 namespace Captura
 {
     public static class SystemTrayManager
     {
-        // Balloon Click Callback
-        static Action _balloonAction;
-        static NotifyIcon _systemTray;
-
-        public static void Init()
-        {
-            _systemTray = new NotifyIcon
-            {
-                // Use the icon from exe file
-                Icon = Icon.ExtractAssociatedIcon("Captura.exe"),
-                //Visible = true,
-                ContextMenu = new ContextMenu()
-            };
-
-            _systemTray.DoubleClick += (s, e) =>
-            {
-                //ServiceProvider.Get<Action>(ServiceName.Focus).Invoke();
-            };
-
-            _systemTray.BalloonTipClicked += (s, e) =>
-            {
-                try { _balloonAction?.Invoke(); }
-                catch
-                {
-                    // Suppress Errors
-                }
-            };
-
-            foreach (var service in new[] { ServiceName.Recording, ServiceName.Pause, ServiceName.ScreenShot, ServiceName.ActiveScreenShot, ServiceName.DesktopScreenShot })
-                _systemTray.ContextMenu.MenuItems.Add(ServiceProvider.GetDescription(service), (s, e) => ServiceProvider.Get<Action>(service).Invoke());
-            
-            var separator = new MenuItem { BarBreak = true };
-
-            _systemTray.ContextMenu.MenuItems.Add(separator);
-
-            _systemTray.ContextMenu.MenuItems.Add("Exit", (s, e) =>
-            {
-                //ServiceProvider.Get<Action>(ServiceName.Exit).Invoke();
-            });
-        }
-        
-        public static void ShowNotification(string Title, string Text, int Duration, Action ClickAction)
-        {
-            if (!Settings.Instance.TrayNotify)
-                return;
-
-            _balloonAction = ClickAction;
-
-            _systemTray.ShowBalloonTip(Duration, Title, Text, ToolTipIcon.None);
-        }
-
-        public static void HideNotification()
-        {
-            _systemTray.Visible = false;
-            _systemTray.Visible = true;
-        }
-
-        public static void Dispose()
-        {
-            // Hide the System Tray
-            _systemTray.Visible = false;
-
-            _systemTray.Dispose();
-        }
+        public static ISystemTray SystemTray { get; } = ServiceProvider.Get<ISystemTray>(ServiceName.SystemTray);
     }
 }

--- a/src/Captura.Core/Models/SystemTrayManager.cs
+++ b/src/Captura.Core/Models/SystemTrayManager.cs
@@ -16,13 +16,13 @@ namespace Captura
             {
                 // Use the icon from exe file
                 Icon = Icon.ExtractAssociatedIcon("Captura.exe"),
-                Visible = true,
+                //Visible = true,
                 ContextMenu = new ContextMenu()
             };
 
             _systemTray.DoubleClick += (s, e) =>
             {
-                ServiceProvider.Get<Action>(ServiceName.Focus).Invoke();
+                //ServiceProvider.Get<Action>(ServiceName.Focus).Invoke();
             };
 
             _systemTray.BalloonTipClicked += (s, e) =>
@@ -43,7 +43,7 @@ namespace Captura
 
             _systemTray.ContextMenu.MenuItems.Add("Exit", (s, e) =>
             {
-                ServiceProvider.Get<Action>(ServiceName.Exit).Invoke();
+                //ServiceProvider.Get<Action>(ServiceName.Exit).Invoke();
             });
         }
         
@@ -55,6 +55,12 @@ namespace Captura
             _balloonAction = ClickAction;
 
             _systemTray.ShowBalloonTip(Duration, Title, Text, ToolTipIcon.None);
+        }
+
+        public static void HideNotification()
+        {
+            _systemTray.Visible = false;
+            _systemTray.Visible = true;
         }
 
         public static void Dispose()

--- a/src/Captura.Core/Services/ServiceName.cs
+++ b/src/Captura.Core/Services/ServiceName.cs
@@ -31,37 +31,12 @@
         /// Get the Window selected in the Window list (Func<Window>).
         /// </summary>
         SelectedWindow,
-
+        
         /// <summary>
-        /// Brings the MainWindow to Focus (Action).
+        /// Get the IRegionProvider.
         /// </summary>
-        Focus,
-
-        /// <summary>
-        /// Exit Application (Action).
-        /// </summary>
-        Exit,
-
-        /// <summary>
-        /// Get RegionItem Video source (IVideoItem).
-        /// </summary>
-        RegionSource,
-
-        /// <summary>
-        /// Control visibility of Region Selector (Action<bool>).
-        /// </summary>
-        RegionSelectorVisibility,
-
-        /// <summary>
-        /// Get Region Rectangle (Func<Rectangle>).
-        /// </summary>
-        RegionRectangle,
-
-        /// <summary>
-        /// Set Region Rectangle (Action<Rectangle>).
-        /// </summary>
-        SetRegionRectangle,
-
+        RegionProvider,
+        
         /// <summary>
         /// Minimize Main Window (Action<bool>).
         /// </summary>

--- a/src/Captura.Core/Services/ServiceName.cs
+++ b/src/Captura.Core/Services/ServiceName.cs
@@ -50,6 +50,11 @@
         /// <summary>
         /// Set MainWindow Location (Action<Point>).
         /// </summary>
-        SetMainWindowLocation
+        SetMainWindowLocation,
+
+        /// <summary>
+        /// Gets the ISystemTray.
+        /// </summary>
+        SystemTray
     }
 }

--- a/src/Captura.Core/ViewModels/MainViewModel.cs
+++ b/src/Captura.Core/ViewModels/MainViewModel.cs
@@ -69,7 +69,7 @@ namespace Captura.ViewModels
             {
                 if (RecorderState == RecorderState.Paused)
                 {
-                    SystemTrayManager.HideNotification();
+                    SystemTrayManager.SystemTray.HideNotification();
 
                     _recorder.Start();
                     _timer.Start();
@@ -85,7 +85,7 @@ namespace Captura.ViewModels
                     RecorderState = RecorderState.Paused;
                     Status = "Paused";
 
-                    SystemTrayManager.ShowNotification("Recording Paused", " ", 500, null);
+                    SystemTrayManager.SystemTray.ShowTextNotification("Recording Paused", 3000, null);
                 }
             }, false);
 
@@ -162,8 +162,6 @@ namespace Captura.ViewModels
 
             HotKeyManager.RegisterAll();
             
-            SystemTrayManager.Init();
-
             #region Restore Video Source
             if (Settings.LastSourceKind == VideoSourceKind.Window)
             {
@@ -252,7 +250,6 @@ namespace Captura.ViewModels
         public void Dispose()
         {
             HotKeyManager.Dispose();
-            SystemTrayManager.Dispose();
 
             AudioViewModel.Dispose();
 
@@ -349,7 +346,7 @@ namespace Captura.ViewModels
                         Status = "Image Saved to Disk";
                         RecentViewModel.Add(fileName, RecentItemType.Image, false);
 
-                        SystemTrayManager.ShowNotification("ScreenShot Saved", Path.GetFileName(fileName), 3000, () => Process.Start(fileName));
+                        SystemTrayManager.SystemTray.ShowScreenShotNotification(fileName);
                     }
                     catch (Exception E)
                     {
@@ -364,7 +361,7 @@ namespace Captura.ViewModels
 
         public Bitmap ScreenShotWindow(Window hWnd)
         {
-            SystemTrayManager.HideNotification();
+            SystemTrayManager.SystemTray.HideNotification();
 
             if (hWnd == Window.DesktopWindow)
                 return ScreenShot.Capture(Settings.IncludeCursor);
@@ -383,7 +380,7 @@ namespace Captura.ViewModels
 
         void CaptureScreenShot()
         {
-            SystemTrayManager.HideNotification();
+            SystemTrayManager.SystemTray.HideNotification();
 
             Bitmap bmp = null;
 
@@ -418,7 +415,7 @@ namespace Captura.ViewModels
 
         void StartRecording()
         {
-            SystemTrayManager.HideNotification();
+            SystemTrayManager.SystemTray.HideNotification();
 
             if (Settings.MinimizeOnStart)
                 ServiceProvider.Get<Action<bool>>(ServiceName.Minimize).Invoke(true);
@@ -560,7 +557,14 @@ namespace Captura.ViewModels
             // After Save
             savingRecentItem.Saved();
 
-            SystemTrayManager.ShowNotification($"{(isVideo ? "Video" : "Audio")} Saved", Path.GetFileName(_currentFileName), 3000, () => Process.Start(_currentFileName));
+            SystemTrayManager.SystemTray.ShowTextNotification($"{(isVideo ? "Video" : "Audio")} Saved: " + Path.GetFileName(_currentFileName), 5000, () => 
+            {
+                try
+                {
+                    Process.Start(_currentFileName);
+                }
+                catch { }
+            });
         }
     }
 }

--- a/src/Captura.Core/ViewModels/Properties.cs
+++ b/src/Captura.Core/ViewModels/Properties.cs
@@ -148,6 +148,10 @@ namespace Captura.ViewModels
         #region Commands
         public DelegateCommand ScreenShotCommand { get; }
 
+        public DelegateCommand ScreenShotActiveCommand { get; }
+
+        public DelegateCommand ScreenShotDesktopCommand { get; }
+
         public DelegateCommand RecordCommand { get; }
 
         public DelegateCommand RefreshCommand { get; }

--- a/src/Captura.Core/ViewModels/VideoViewModel.cs
+++ b/src/Captura.Core/ViewModels/VideoViewModel.cs
@@ -1,6 +1,5 @@
 using Captura.Models;
 using Screna;
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -9,8 +8,12 @@ namespace Captura.ViewModels
 {
     public class VideoViewModel : ViewModelBase
     {
+        public IRegionProvider RegionProvider { get; }
+
         public VideoViewModel()
         {
+            RegionProvider = ServiceProvider.Get<IRegionProvider>(ServiceName.RegionProvider);
+
             // Check if there are multiple Screens
             if (ScreenItem.Count > 1)
                 AvailableVideoSourceKinds.Add(new KeyValuePair<VideoSourceKind, string>(VideoSourceKind.Screen, "Screen"));
@@ -68,7 +71,7 @@ namespace Captura.ViewModels
                     break;
 
                 case VideoSourceKind.Region:
-                    AvailableVideoSources.Add(ServiceProvider.Get<IVideoItem>(ServiceName.RegionSource));
+                    AvailableVideoSources.Add(RegionProvider.VideoSource);
                     break;
             }
 
@@ -77,7 +80,7 @@ namespace Captura.ViewModels
                 SelectedVideoSource = AvailableVideoSources[0];
 
             // RegionSelector should only be shown on Region Capture.
-            ServiceProvider.Get<Action<bool>>(ServiceName.RegionSelectorVisibility).Invoke(SelectedVideoSourceKind == VideoSourceKind.Region);
+            RegionProvider.SelectorVisible = SelectedVideoSourceKind == VideoSourceKind.Region;
         }
         
         void InitSharpAviCodecs()

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -57,6 +57,13 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Models\RegionProvider.cs" />
+    <Compile Include="Models\SystemTray.cs" />
+    <Compile Include="Presentation\Controls\TextBalloon.xaml.cs">
+      <DependentUpon>TextBalloon.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Presentation\Controls\ScreenShotBalloon.xaml.cs">
+      <DependentUpon>ScreenShotBalloon.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Presentation\Controls\HotkeySelector.cs" />
     <Compile Include="Presentation\Controls\ModernToggleButton.cs" />
     <Compile Include="Presentation\Controls\ModernButton.cs" />
@@ -105,6 +112,14 @@
     <Page Include="Languages\lang.en-US.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Presentation\Controls\TextBalloon.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Presentation\Controls\ScreenShotBalloon.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Presentation\Themes\Button.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -38,6 +38,9 @@
     <StartupObject>Captura.App</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Hardcodet.Wpf.TaskbarNotification, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.8\lib\net451\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
@@ -53,6 +56,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Models\RegionProvider.cs" />
     <Compile Include="Presentation\Controls\HotkeySelector.cs" />
     <Compile Include="Presentation\Controls\ModernToggleButton.cs" />
     <Compile Include="Presentation\Controls\ModernButton.cs" />
@@ -223,6 +227,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <SplashScreen Include="Logo.png" />

--- a/src/Captura/MainWindow.xaml
+++ b/src/Captura/MainWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="Captura.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:tb="http://www.hardcodet.net/taskbar"
         xmlns:local="clr-namespace:Captura"
         WindowState="{Binding WindowState}"
         DataContext="{StaticResource MainViewModel}"
@@ -48,6 +49,18 @@
                 </Setter.Value>
             </Setter>
         </Style>
+        <DrawingImage x:Key="RecordStopImageSource">
+            <DrawingImage.Drawing>
+                <GeometryDrawing Geometry="{Binding RecorderState, Converter={StaticResource StateToRecordButtonGeometryConverter}}"
+                                                             Brush="#b71c1c"/>
+            </DrawingImage.Drawing>
+        </DrawingImage>
+        <DrawingImage x:Key="ScreenShotImageSource">
+            <DrawingImage.Drawing>
+                <GeometryDrawing Geometry="M4,4H7L9,2H15L17,4H20A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4M12,7A5,5 0 0,0 7,12A5,5 0 0,0 12,17A5,5 0 0,0 17,12A5,5 0 0,0 12,7M12,9A3,3 0 0,1 15,12A3,3 0 0,1 12,15A3,3 0 0,1 9,12A3,3 0 0,1 12,9Z"
+                                                 Brush="#cccccc"/>
+            </DrawingImage.Drawing>
+        </DrawingImage>
     </Window.Resources>
     <Window.TaskbarItemInfo>
         <TaskbarItemInfo Overlay="{Binding RecorderState, Converter={StaticResource StateToTaskbarOverlayConverter}}"
@@ -55,32 +68,60 @@
             <TaskbarItemInfo.ThumbButtonInfos>
                 <ThumbButtonInfo Command="{Binding ScreenShotCommand}"
                                  Description="{DynamicResource s_ScreenShot}"
-                                 DismissWhenClicked="True">
-                    <ThumbButtonInfo.ImageSource>
-                        <DrawingImage>
-                            <DrawingImage.Drawing>
-                                <GeometryDrawing Geometry="M4,4H7L9,2H15L17,4H20A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4M12,7A5,5 0 0,0 7,12A5,5 0 0,0 12,17A5,5 0 0,0 17,12A5,5 0 0,0 12,7M12,9A3,3 0 0,1 15,12A3,3 0 0,1 12,15A3,3 0 0,1 9,12A3,3 0 0,1 12,9Z"
-                                                 Brush="#cccccc"/>
-                            </DrawingImage.Drawing>
-                        </DrawingImage>
-                    </ThumbButtonInfo.ImageSource>
-                </ThumbButtonInfo>
+                                 DismissWhenClicked="True"
+                                 ImageSource="{StaticResource ScreenShotImageSource}"/>
                 <ThumbButtonInfo Command="{Binding RecordCommand}"
                                  Description="{DynamicResource s_RecordStop}"
-                                 DismissWhenClicked="True">
-                    <ThumbButtonInfo.ImageSource>
-                        <DrawingImage>
-                            <DrawingImage.Drawing>
-                                <GeometryDrawing Geometry="{Binding RecorderState, Converter={StaticResource StateToRecordButtonGeometryConverter}}"
-                                                 Brush="#b71c1c"/>
-                            </DrawingImage.Drawing>
-                        </DrawingImage>
-                    </ThumbButtonInfo.ImageSource>
-                </ThumbButtonInfo>
+                                 DismissWhenClicked="True"
+                                 ImageSource="{StaticResource RecordStopImageSource}"/>
             </TaskbarItemInfo.ThumbButtonInfos>
         </TaskbarItemInfo>
     </Window.TaskbarItemInfo>
     <Grid Background="#BDBDBD">
+        <!-- NotifyIcon -->
+        <tb:TaskbarIcon x:Name="SystemTray"
+                        IconSource="Captura.ico"
+                        ToolTipText="{DynamicResource s_Title}"
+                        TrayMouseDoubleClick="SystemTray_TrayMouseDoubleClick">
+            <tb:TaskbarIcon.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Start/Stop _Recording [R]"
+                              Command="{Binding RecordCommand}">
+                        <MenuItem.Icon>
+                            <Image Source="{StaticResource RecordStopImageSource}"
+                                   Width="15"
+                                   Margin="5"/>
+                        </MenuItem.Icon>
+                    </MenuItem>
+
+                    <MenuItem Header="_Pause/Resume Recording [P]"
+                              Command="{Binding PauseCommand}"/>
+
+                    <Separator/>
+
+                    <MenuItem Header="_ScreenShot [S]"
+                              Command="{Binding ScreenShotCommand}">
+                        <MenuItem.Icon>
+                            <Image Source="{StaticResource ScreenShotImageSource}"
+                                   Width="15"
+                                   Margin="5"/>
+                        </MenuItem.Icon>
+                    </MenuItem>
+
+                    <MenuItem Header="ScreenShot _Active Window [A]"
+                              Command="{Binding ScreenShotActiveCommand}"/>
+
+                    <MenuItem Header="ScreenShot _Desktop Window [D]"
+                              Command="{Binding ScreenShotDesktopCommand}"/>
+
+                    <Separator/>
+
+                    <MenuItem Header="E_xit [X]"
+                              Click="MenuExit_Click"/>
+                </ContextMenu>
+            </tb:TaskbarIcon.ContextMenu>
+        </tb:TaskbarIcon>
+
         <Expander Padding="5,0,0,0"
                   IsExpanded="True">
             <Expander.HeaderTemplate>

--- a/src/Captura/MainWindow.xaml.cs
+++ b/src/Captura/MainWindow.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using Captura.Models;
 using Captura.ViewModels;
 using System;
-using System.Drawing;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
@@ -13,31 +12,7 @@ namespace Captura
     {        
         public MainWindow()
         {
-            ServiceProvider.Register<Action>(ServiceName.Focus, () =>
-            {
-                Show();
-                WindowState = WindowState.Normal;
-                Focus();
-            });
-
-            ServiceProvider.Register<Action>(ServiceName.Exit, () =>
-            {
-                (DataContext as MainViewModel).Dispose();
-                Application.Current.Shutdown();
-            });
-
-            ServiceProvider.Register<IVideoItem>(ServiceName.RegionSource, RegionItem.Instance);
-
-            ServiceProvider.Register<Action<bool>>(ServiceName.RegionSelectorVisibility, visible =>
-            {
-                if (visible)
-                    RegionSelector.Instance.Show();
-                else RegionSelector.Instance.Hide();
-            });
-
-            ServiceProvider.Register<Func<Rectangle>>(ServiceName.RegionRectangle, () => RegionSelector.Instance.Rectangle);
-
-            ServiceProvider.Register<Action<Rectangle>>(ServiceName.SetRegionRectangle, rect => RegionSelector.Instance.Rectangle = rect);
+            ServiceProvider.Register<IRegionProvider>(ServiceName.RegionProvider, new RegionProvider());
 
             ServiceProvider.Register<Action<bool>>(ServiceName.Minimize, minimize =>
             {
@@ -67,10 +42,7 @@ namespace Captura
 
             InitializeComponent();
             
-            Closed += (s, e) =>
-            {
-                ServiceProvider.Get<Action>(ServiceName.Exit).Invoke();
-            };
+            Closed += (s, e) => MenuExit_Click();
         }
 
         protected override void OnStateChanged(EventArgs e)
@@ -91,5 +63,25 @@ namespace Captura
         void MinButton_Click(object sender, RoutedEventArgs e) => WindowState = WindowState.Minimized;
 
         void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+
+        void SystemTray_TrayMouseDoubleClick(object sender, RoutedEventArgs e)
+        {
+            if (Visibility == Visibility.Visible)
+            {
+                Hide();
+            }
+            else
+            {
+                Show();
+                Focus();
+            }
+        }
+
+        void MenuExit_Click(object sender = null, RoutedEventArgs e = null)
+        {
+            (DataContext as MainViewModel).Dispose();
+            SystemTray.Dispose();
+            Application.Current.Shutdown();
+        }
     }
 }

--- a/src/Captura/MainWindow.xaml.cs
+++ b/src/Captura/MainWindow.xaml.cs
@@ -13,7 +13,7 @@ namespace Captura
         public MainWindow()
         {
             ServiceProvider.Register<IRegionProvider>(ServiceName.RegionProvider, new RegionProvider());
-
+            
             ServiceProvider.Register<Action<bool>>(ServiceName.Minimize, minimize =>
             {
                 WindowState = minimize ? WindowState.Minimized : WindowState.Normal;
@@ -41,7 +41,9 @@ namespace Captura
             };
 
             InitializeComponent();
-            
+
+            ServiceProvider.Register<ISystemTray>(ServiceName.SystemTray, new SystemTray(SystemTray));
+
             Closed += (s, e) => MenuExit_Click();
         }
 

--- a/src/Captura/Models/RegionProvider.cs
+++ b/src/Captura/Models/RegionProvider.cs
@@ -1,0 +1,28 @@
+﻿using System.Drawing;
+using Captura.Models;
+using System.Windows;
+
+namespace Captura
+{
+    class RegionProvider : IRegionProvider
+    {
+        public bool SelectorVisible
+        {
+            get => RegionSelector.Instance.Visibility == Visibility.Visible;
+            set
+            {
+                if (value)
+                    RegionSelector.Instance.Show();
+                else RegionSelector.Instance.Hide();
+            }
+        }
+
+        public Rectangle SelectedRegion
+        {
+            get => RegionSelector.Instance.Rectangle;
+            set => RegionSelector.Instance.Rectangle = value;
+        }
+
+        public IVideoItem VideoSource => RegionItem.Instance;
+    }
+}

--- a/src/Captura/Models/SystemTray.cs
+++ b/src/Captura/Models/SystemTray.cs
@@ -1,0 +1,41 @@
+﻿using Hardcodet.Wpf.TaskbarNotification;
+using System;
+using System.Windows.Controls.Primitives;
+
+namespace Captura.Models
+{
+    class SystemTray : ISystemTray
+    {
+        TaskbarIcon _trayIcon;
+
+        public SystemTray(TaskbarIcon TaskbarIcon)
+        {
+            _trayIcon = TaskbarIcon;
+        }
+
+        public void HideNotification()
+        {
+            _trayIcon.CloseBalloon();
+        }
+
+        public void ShowScreenShotNotification(string FilePath)
+        {
+            if (!Settings.Instance.TrayNotify)
+                return;
+
+            var popup = new ScreenShotBalloon(FilePath);
+            
+            _trayIcon.ShowCustomBalloon(popup, PopupAnimation.Scroll, 5000);
+        }
+
+        public void ShowTextNotification(string Text, int Duration, Action OnClick)
+        {
+            if (!Settings.Instance.TrayNotify)
+                return;
+
+            var balloon = new TextBalloon(Text, OnClick);
+
+            _trayIcon.ShowCustomBalloon(balloon, PopupAnimation.Scroll, Duration);
+        }
+    }
+}

--- a/src/Captura/Presentation/Controls/ScreenShotBalloon.xaml
+++ b/src/Captura/Presentation/Controls/ScreenShotBalloon.xaml
@@ -1,0 +1,33 @@
+﻿<UserControl x:Class="Captura.ScreenShotBalloon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Captura"
+             x:Name="me"
+             Background="#333333"
+             Foreground="White"
+             Width="400"
+             Margin="30,60"
+             BorderThickness="1"
+             BorderBrush="{DynamicResource Accent}">
+    <DockPanel MouseEnter="grid_MouseEnter">
+        <DockPanel DockPanel.Dock="Top">
+            <local:ModernButton ToolTip="{DynamicResource s_Close}"
+                            Click="CloseButton_Click"
+                            Foreground="LightPink"
+                            IconData="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+                            DockPanel.Dock="Right"/>
+            <TextBlock Text="ScreenShot Saved"
+                       VerticalAlignment="Center"
+                       Margin="5"/>
+        </DockPanel>
+
+        <TextBlock Text="{Binding FileName, ElementName=me}"
+                   DockPanel.Dock="Bottom"
+                   Padding="5"/>
+        
+        <Image Source="{Binding FilePath, ElementName=me}"
+               Cursor="Hand"
+               MouseUp="Image_MouseUp"
+               Margin="5"/>
+    </DockPanel>
+</UserControl>

--- a/src/Captura/Presentation/Controls/ScreenShotBalloon.xaml.cs
+++ b/src/Captura/Presentation/Controls/ScreenShotBalloon.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Hardcodet.Wpf.TaskbarNotification;
+using System.IO;
+using System.Diagnostics;
+
+namespace Captura
+{
+    public partial class ScreenShotBalloon : UserControl
+    {
+        public string FileName { get; }
+
+        public string FilePath { get; }
+
+        public ScreenShotBalloon(string FilePath)
+        {
+            this.FilePath = FilePath;
+            FileName = Path.GetFileName(FilePath);
+
+            InitializeComponent();
+        }
+
+        public void CloseButton_Click(object sender = null, RoutedEventArgs e = null)
+        {
+            //the tray icon assigned this attached property to simplify access
+            var taskbarIcon = TaskbarIcon.GetParentTaskbarIcon(this);
+            taskbarIcon.CloseBalloon();
+        }
+
+        /// <summary>
+        /// If the users hovers over the balloon, we don't close it.
+        /// </summary>
+        void grid_MouseEnter(object sender, MouseEventArgs e)
+        {
+            // the tray icon assigned this attached property to simplify access
+            var taskbarIcon = TaskbarIcon.GetParentTaskbarIcon(this);
+            taskbarIcon.ResetBalloonCloseTimer();
+        }
+
+        void Image_MouseUp(object sender, MouseButtonEventArgs e)
+        {
+            try { Process.Start(FilePath); }
+            catch { }
+
+            CloseButton_Click();
+        }
+    }
+}

--- a/src/Captura/Presentation/Controls/TextBalloon.xaml
+++ b/src/Captura/Presentation/Controls/TextBalloon.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl x:Class="Captura.TextBalloon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Captura"
+             x:Name="me"
+             Background="#333333"
+             Foreground="White"
+             Width="400"
+             Margin="0,60"
+             BorderThickness="1"
+             BorderBrush="{DynamicResource Accent}">
+    <DockPanel MouseEnter="grid_MouseEnter">
+        <local:ModernButton ToolTip="{DynamicResource s_Close}"
+                            Click="CloseButton_Click"
+                            Foreground="LightPink"
+                            IconData="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+                            DockPanel.Dock="Right"/>
+        <TextBlock Text="{Binding Text, ElementName=me}"
+                   VerticalAlignment="Center"
+                   Padding="5"
+                   MouseUp="TextBlock_MouseUp"
+                   Cursor="Hand"/>
+    </DockPanel>
+</UserControl>

--- a/src/Captura/Presentation/Controls/TextBalloon.xaml.cs
+++ b/src/Captura/Presentation/Controls/TextBalloon.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Hardcodet.Wpf.TaskbarNotification;
+using System;
+
+namespace Captura
+{
+    public partial class TextBalloon : UserControl
+    {
+        public string Text { get; }
+
+        Action _onClick;
+        
+        public TextBalloon(string Text, Action OnClick)
+        {
+            this.Text = Text;
+
+            _onClick = OnClick;
+
+            InitializeComponent();
+        }
+
+        public void CloseButton_Click(object sender = null, RoutedEventArgs e = null)
+        {
+            //the tray icon assigned this attached property to simplify access
+            var taskbarIcon = TaskbarIcon.GetParentTaskbarIcon(this);
+            taskbarIcon.CloseBalloon();
+        }
+
+        /// <summary>
+        /// If the users hovers over the balloon, we don't close it.
+        /// </summary>
+        void grid_MouseEnter(object sender, MouseEventArgs e)
+        {
+            // the tray icon assigned this attached property to simplify access
+            var taskbarIcon = TaskbarIcon.GetParentTaskbarIcon(this);
+            taskbarIcon.ResetBalloonCloseTimer();
+        }
+
+        void TextBlock_MouseUp(object sender, MouseButtonEventArgs e)
+        {
+            _onClick?.Invoke();
+
+            CloseButton_Click();
+        }
+    }
+}

--- a/src/Captura/packages.config
+++ b/src/Captura/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
## Using Hardcodec.NotifyIconWpf from NuGet
- Icons in context menu
- Data Binding
- Handled in View part
- Double click tray icon to show/hide MainWindow
- Improved Notifications.

## Services
- Removed Exit, Focus servies.
- IRegionProvider replaces the 4 Region services.
- ISystemTray replaces SystemTrayManager.