### PR TITLE
Organize Appveyor scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build:
   publish_nuget_symbols: true
 
 after_build:
-  -ps: appveyor/Pack-Release.ps1
+  - ps: appveyor/Pack-Release.ps1
 
   - ps: appveyor/Choco.ps1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,14 +24,33 @@ cache:
 before_build:
   # Retrieve version from AssemblyInfo.cs
   - ps: >-
-      $content = Get-Content "src\Captura\Properties\AssemblyInfo.cs";
-      $match = [regex]::Match($content, 'AssemblyVersion\(\"(.+?)\"\)');
+      $assemblyInfo = "src\Captura\Properties\AssemblyInfo.cs";
 
-      if ($match.Success)
+      if ($env:appveyor_repo_tag -eq 'true')
       {
-        $env:AppVersion = $match.Groups[1].Value;
-        Update-AppveyorBuild -Version "$env:AppVersion.$env:APPVEYOR_BUILD_NUMBER";
+        if (-not ($env:APPVEYOR_REPO_TAG_NAME -match '^v\d+\.\d+\.\d+$'))
+        {
+          throw 'Invalid Tag Format';
+        }
+
+        $env:AppVersion = ($env:APPVEYOR_REPO_TAG_NAME).Substring(1);
+
+        $content = Get-Content $assemblyInfo;
+        $replaced = $content -replace 'AssemblyVersion\(\".+?\"\)', "AssemblyVersion(\"$env:AppVersion\")";
+        Set-Content $assemblyInfo $replaced;
       }
+      else
+      {
+        $content = Get-Content $assemblyInfo;
+        $match = [regex]::Match($content, 'AssemblyVersion\(\"(.+?)\"\)');
+
+        if ($match.Success)
+        {
+          $env:AppVersion = $match.Groups[1].Value;          
+        }
+      }
+
+      Update-AppveyorBuild -Version "$env:AppVersion.$env:APPVEYOR_BUILD_NUMBER";
 
 build:
   parallel: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,51 +6,15 @@ configuration:
 - Debug
 - Release
 
-environment:
-  # Will be updated Before Build
-  AppVersion: 1.0.0
-
 install:
-  # Update Submodules
-  - git submodule update --init
-
-  # Restore packages
-  - nuget restore src/Captura.sln
+- ps: appveyor/Install.ps1
 
 cache:
   # preserve "packages" directory but reset if packages.config is modified
   - src\packages -> **\packages.config
 
 before_build:
-  # Retrieve version from AssemblyInfo.cs
-  - ps: >-
-      $assemblyInfo = "src\Captura\Properties\AssemblyInfo.cs";
-
-      if ($env:appveyor_repo_tag -eq 'true')
-      {
-        if (-not ($env:APPVEYOR_REPO_TAG_NAME -match '^v\d+\.\d+\.\d+$'))
-        {
-          throw 'Invalid Tag Format';
-        }
-
-        $env:AppVersion = ($env:APPVEYOR_REPO_TAG_NAME).Substring(1);
-
-        $content = Get-Content $assemblyInfo;
-        $replaced = $content -replace 'AssemblyVersion\(\".+?\"\)', "AssemblyVersion(`"$env:AppVersion`")";
-        Set-Content $assemblyInfo $replaced;
-      }
-      else
-      {
-        $content = Get-Content $assemblyInfo;
-        $match = [regex]::Match($content, 'AssemblyVersion\(\"(.+?)\"\)');
-
-        if ($match.Success)
-        {
-          $env:AppVersion = $match.Groups[1].Value;          
-        }
-      }
-
-      Update-AppveyorBuild -Version "$env:AppVersion.$env:APPVEYOR_BUILD_NUMBER";
+  - ps: appveyor/Update-Version.ps1
 
 build:
   parallel: true
@@ -60,54 +24,9 @@ build:
   publish_nuget_symbols: true
 
 after_build:
-  # Create output and temp folder
-  - md Output
-  - md temp
+  -ps: appveyor/Pack-Release.ps1
 
-  # Copy licenses
-  - xcopy /s licenses Output\licenses\
-
-  # Copy build output
-  - ps: >-
-      if ($env:configuration -eq 'Release')
-      {
-        Get-ChildItem -Path 'src/Captura/bin/Release/*' -Include *.exe*, *.dll | Copy-Item -Destination 'Output/'
-      }
-      elseif ($env:configuration -eq 'Debug')
-      {
-        Get-ChildItem -Path 'src/Captura/bin/Debug/*' -Include *.exe*, *.dll, *.pdb, *.xml | Copy-Item -Destination 'Output/'
-      }
-
-  # Download BASS and BassMix
-  - ps: Invoke-WebRequest "http://www.un4seen.com/files/bass24.zip" -OutFile "temp/bass.zip"
-  - ps: Invoke-WebRequest "http://www.un4seen.com/files/bassmix24.zip" -OutFile "temp/bassmix.zip"
-
-  # Extract BASS and BassMix
-  - ps: Expand-Archive "temp/bass.zip" "temp/bass"
-  - ps: Expand-Archive "temp/bassmix.zip" "temp/bassmix"
-
-  # Copy BASS and BassMix
-  - ps: Copy-Item 'temp/bass/bass.dll', 'temp/bassmix/bassmix.dll' 'Output/'
-
-  # Pack Deploy zip
-  - ps: Compress-Archive 'Output\*' "Output\Captura-$env:configuration.zip"
-
-  # Chocolatey
-  - ps: >-
-      if ($env:configuration -eq 'Release' -and $env:appveyor_repo_tag -eq 'true')
-      {
-        $checksum = (Get-FileHash "Output/Captura-Release.zip").Hash;
-
-        $installScript = "choco/tools/chocolateyinstall.ps1";
-
-        $scriptContent = "`n`n" + (Get-Content $installScript);
-
-        # Update chocolatey install script
-        Set-Content $installScript (('$tag = "{0}"; $checksum = "{1}";{2}') -f $env:APPVEYOR_REPO_TAG_NAME, $checksum, $scriptContent);
-
-        choco pack choco/captura.nuspec --version $env:AppVersion;
-        Push-AppVeyorArtifact "captura.$env:AppVersion.nupkg" -DeploymentName Chocolatey;
-      }
+  - ps: appveyor/Choco.ps1
 
 artifacts:
   - path: Output/Captura-$(configuration).zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ before_build:
         $env:AppVersion = ($env:APPVEYOR_REPO_TAG_NAME).Substring(1);
 
         $content = Get-Content $assemblyInfo;
-        $replaced = $content -replace 'AssemblyVersion\(\".+?\"\)', "AssemblyVersion(\"$env:AppVersion\")";
+        $replaced = $content -replace 'AssemblyVersion\(\".+?\"\)', "AssemblyVersion(`"$env:AppVersion`")";
         Set-Content $assemblyInfo $replaced;
       }
       else

--- a/appveyor/Choco.ps1
+++ b/appveyor/Choco.ps1
@@ -1,0 +1,19 @@
+# Prepare Chocolatey package only on Release Tag builds
+if ($env:configuration -eq 'Release' -and $env:appveyor_repo_tag -eq 'true')
+{
+    # sha256 Checksum
+    $checksum = (Get-FileHash "Output/Captura-Release.zip").Hash
+
+    $installScript = "choco/tools/chocolateyinstall.ps1"
+
+    $scriptContent = "`n`n" + (Get-Content $installScript)
+
+    # Update chocolatey install script
+    Set-Content $installScript (('$tag = "{0}"; $checksum = "{1}";{2}') -f $env:APPVEYOR_REPO_TAG_NAME, $checksum, $scriptContent)
+
+    # Pack Chocolatey Package with Tag version
+    choco pack choco/captura.nuspec --version $env:AppVersion
+
+    # Upload as Artifact. Can be later published using Deploy button.
+    Push-AppVeyorArtifact "captura.$env:AppVersion.nupkg" -DeploymentName Chocolatey
+}

--- a/appveyor/Install.ps1
+++ b/appveyor/Install.ps1
@@ -1,0 +1,5 @@
+# Update Submodules
+git submodule update --init
+
+# Restore packages
+nuget restore src/Captura.sln

--- a/appveyor/Pack-Release.ps1
+++ b/appveyor/Pack-Release.ps1
@@ -1,0 +1,30 @@
+# Create output and temp folder
+md Output
+md temp
+
+# Copy licenses
+Copy-Item licenses Output -Recurse
+
+# Copy build output
+if ($env:configuration -eq 'Release')
+{
+    Get-ChildItem -Path 'src/Captura/bin/Release/*' -Include *.exe*, *.dll | Copy-Item -Destination 'Output/'
+}
+elseif ($env:configuration -eq 'Debug')
+{
+    Get-ChildItem -Path 'src/Captura/bin/Debug/*' -Include *.exe*, *.dll, *.pdb, *.xml | Copy-Item -Destination 'Output/'
+}
+
+# Download BASS and BassMix
+Invoke-WebRequest "http://www.un4seen.com/files/bass24.zip" -OutFile "temp/bass.zip"
+Invoke-WebRequest "http://www.un4seen.com/files/bassmix24.zip" -OutFile "temp/bassmix.zip"
+
+# Extract BASS and BassMix
+Expand-Archive "temp/bass.zip" "temp/bass"
+Expand-Archive "temp/bassmix.zip" "temp/bassmix"
+
+# Copy BASS and BassMix
+Copy-Item 'temp/bass/bass.dll', 'temp/bassmix/bassmix.dll' 'Output/'
+
+# Pack Deploy zip
+Compress-Archive 'Output\*' "Output\Captura-$env:configuration.zip"

--- a/appveyor/Update-Version.ps1
+++ b/appveyor/Update-Version.ps1
@@ -1,0 +1,37 @@
+# Path to AssemblyInfo.cs file
+$assemblyInfo = "src\Captura\Properties\AssemblyInfo.cs"
+
+# Default Version
+$env:AppVersion = "1.0.0"
+
+# For Tag build
+if ($env:appveyor_repo_tag -eq 'true')
+{
+    # Check tag name format
+    if (-not ($env:APPVEYOR_REPO_TAG_NAME -match '^v\d+\.\d+\.\d+$'))
+    {
+        throw 'Invalid Tag Format'
+    }
+
+    # Extract AppVersion from Tag name
+    $env:AppVersion = ($env:APPVEYOR_REPO_TAG_NAME).Substring(1)
+
+    # Update AssemblyInfo.cs with Version from tag
+    $content = Get-Content $assemblyInfo
+    $replaced = $content -replace 'AssemblyVersion\(\".+?\"\)', "AssemblyVersion(`"$env:AppVersion`")"
+    Set-Content $assemblyInfo $replaced
+}
+else
+{
+    # Retrieve Version from AssemblyInfo.cs
+    $content = Get-Content $assemblyInfo
+    $match = [regex]::Match($content, 'AssemblyVersion\(\"(.+?)\"\)')
+
+    if ($match.Success)
+    {
+        $env:AppVersion = $match.Groups[1].Value
+    }
+}
+
+# Update Appveyor Build Version
+Update-AppveyorBuild -Version "$env:AppVersion.$env:APPVEYOR_BUILD_NUMBER"


### PR DESCRIPTION
- Scripts in `appveyor` folder.
- Tag format is enforced.
- For tag builds, version is determined from tag.