### PR TITLE
Update Build Notes. Add Steps for compilation via VS2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ choco install captura -y
 - Can be used from [Command-line](http://mathewsachin.github.io/Captura/Manual/cmdline.html).
 
 # Build Notes
-- [Visual Studio 2017](https://visualstudio.com) or greater is required.
+- [Visual Studio 2017](https://visualstudio.com) or greater is recommended. Can also be build using Visual Studio 2015 using [Microsoft.Net.Compilers](https://www.nuget.org/packages/Microsoft.Net.Compilers) nuget package to support compilation of C# 7.
 - .Net Framework v4.6.1 is required.
 - **Clone submodules:** Open a terminal in the project folder and type `git submodule update --init`.
 


### PR DESCRIPTION
Hi,
I have updated Build Notes to add compilation steps using VS2015 and have successfully tested it.
![pr](https://user-images.githubusercontent.com/3725386/27300057-d9a51e32-5547-11e7-8ff3-b945f94508d6.PNG)
