### PR TITLE
Use VistaFolderBrowserDialog instead of FolderBrowserDialog

### DIFF
--- a/licenses/Ooki.Dialogs.txt
+++ b/licenses/Ooki.Dialogs.txt
@@ -1,0 +1,29 @@
+License agreement for Ookii.Dialogs.
+
+Copyright © Sven Groot (Ookii.org) 2009
+All rights reserved.
+
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+1) Redistributions of source code must retain the above copyright notice, 
+   this list of conditions and the following disclaimer. 
+2) Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+3) Neither the name of the ORGANIZATION nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/Captura.Core/Captura.Core.csproj
+++ b/src/Captura.Core/Captura.Core.csproj
@@ -37,6 +37,10 @@
     <Reference Include="ManagedBass.Mix, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ManagedBass.Mix.2.0.0\lib\netstandard1.4\ManagedBass.Mix.dll</HintPath>
     </Reference>
+    <Reference Include="Ookii.Dialogs, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0c15020868fd6249, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ookii.Dialogs.WindowsForms.1.0\lib\net35\Ookii.Dialogs.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="SharpAvi, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpAvi.2.1.0\lib\net45\SharpAvi.dll</HintPath>
     </Reference>

--- a/src/Captura.Core/ViewModels/Properties.cs
+++ b/src/Captura.Core/ViewModels/Properties.cs
@@ -1,5 +1,6 @@
 ﻿using Captura.Models;
 using Captura.Properties;
+using Ookii.Dialogs;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -162,7 +163,7 @@ namespace Captura.ViewModels
 
         public DelegateCommand SelectOutputFolderCommand { get; } = new DelegateCommand(() =>
         {
-            var dlg = new FolderBrowserDialog
+            var dlg = new VistaFolderBrowserDialog
             {
                 SelectedPath = Settings.Instance.OutPath,
                 Description = Resources.SelectOutFolder
@@ -174,7 +175,7 @@ namespace Captura.ViewModels
 
         public DelegateCommand SelectFFMpegFolderCommand { get; } = new DelegateCommand(() =>
         {
-            var dlg = new FolderBrowserDialog
+            var dlg = new VistaFolderBrowserDialog
             {
                 SelectedPath = Settings.Instance.FFMpegFolder,
                 Description = Resources.SelectFFMpegFolder

--- a/src/Captura.Core/packages.config
+++ b/src/Captura.Core/packages.config
@@ -3,5 +3,6 @@
   <package id="ManagedBass" version="2.0.1" targetFramework="net461" />
   <package id="ManagedBass.Mix" version="2.0.0" targetFramework="net461" />
   <package id="MouseKeyHook" version="5.4.0" targetFramework="net45" />
+  <package id="Ookii.Dialogs.WindowsForms" version="1.0" targetFramework="net461" />
   <package id="SharpAvi" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
VistaFolderBrowserDialog is better alternative of FolderBrowserDialog.
It has many enhancements.
![image](https://user-images.githubusercontent.com/3725386/27518721-b6bccbf6-59ff-11e7-831c-7acf3a8cbb25.png)

It will automatically fall back to legacy FolderBrowserDialog on unsupported windows (e.g. WIndows XP).

**References:**

- https://mking.io/blog/a-better-alternative-to-the-winforms-folderbrowserdialog-using-ookii-dialogs

- http://www.ookii.org/software/dialogs/
