### PR TITLE
CLI FFMpeg Install

### DIFF
--- a/src/Captura.Console/Captura.Console.csproj
+++ b/src/Captura.Console/Captura.Console.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="CmdOptions\CmdOptionsBase.cs" />
     <Compile Include="CmdOptions\CommonCmdOptions.cs" />
+    <Compile Include="CmdOptions\FFMpegCmdOptions.cs" />
     <Compile Include="Fakes\FakeMessageProvider.cs" />
     <Compile Include="Fakes\FakeRegionItem.cs" />
     <Compile Include="Fakes\FakeRegionProvider.cs" />

--- a/src/Captura.Console/CmdOptions/FFMpegCmdOptions.cs
+++ b/src/Captura.Console/CmdOptions/FFMpegCmdOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using CommandLine;
+
+
+namespace Captura
+{
+    public class FFMpegCmdOptions
+    {
+        [Option("install", DefaultValue = null, HelpText = "Install FFMPeg to specified folder.")]
+        public string install { get; set; }
+    }
+}

--- a/src/Captura.Console/CmdOptions/VerbCmdOptions.cs
+++ b/src/Captura.Console/CmdOptions/VerbCmdOptions.cs
@@ -9,5 +9,8 @@ namespace Captura
 
         [VerbOption("shot")]
         public ShotCmdOptions Shot { get; set; }
+
+        [VerbOption("ffmpeg")]
+        public FFMpegCmdOptions Get { get; set; }
     }
 }

--- a/src/Captura.Console/Program.cs
+++ b/src/Captura.Console/Program.cs
@@ -24,6 +24,7 @@ namespace Captura.Console
             {
                 case "start":
                 case "shot":
+                case "ffmpeg":
                     Banner();
 
                     // Reset settings
@@ -49,6 +50,10 @@ namespace Captura.Console
                             else if (Options is ShotCmdOptions shotOptions)
                             {
                                 Shot(vm, shotOptions);
+                            }
+                            else if (Options is FFMpegCmdOptions ffmpegOptions)
+                            {
+                                FFMpeg(vm, ffmpegOptions);
                             }
                         }
                     }))
@@ -300,6 +305,28 @@ namespace Captura.Console
             else if (StartOptions.Encoder == "gif")
             {
                 video.SelectedVideoWriterKind = VideoWriterKind.Gif;
+            }
+        }
+
+        static void FFMpeg(MainViewModel ViewModel, FFMpegCmdOptions ffmpegOptions)
+        {
+
+            if (ffmpegOptions.install != null)
+            {
+                var downloadFolder = ffmpegOptions.install;
+
+                if (!System.IO.Directory.Exists(downloadFolder))
+                {
+                    WriteLine("Directory doesn't exist");
+                    return;
+                }
+
+                var ffMpegDownload = new FFMpegDownloadViewModel();
+                ffMpegDownload.TargetFolder = ffmpegOptions.install;
+                Task downloadTask = Task.Run(() => ffMpegDownload.Start());
+                downloadTask.Wait();
+
+                WriteLine(ffMpegDownload.Status);
             }
         }
 

--- a/src/Captura.Core/ViewModels/FFMpgDownloadViewModel.cs
+++ b/src/Captura.Core/ViewModels/FFMpgDownloadViewModel.cs
@@ -49,7 +49,7 @@ namespace Captura.ViewModels
 
         WebClient web;
 
-        async Task Start()
+        public async Task Start()
         {
             if (ActionDescription == CancelDownload)
             {
@@ -153,7 +153,7 @@ namespace Captura.ViewModels
         public string TargetFolder
         {
             get => _targetFolder;
-            private set
+            set
             {
                 _targetFolder = value;
 


### PR DESCRIPTION
Can now call captura ffmpeg --install [path] and ffmpeg will be installed to the specified location.

This uses the code already in the FFMpgDownloadViewModel.cs but calls it synchronously from the command-line.

As I imagine CLI use is primarily for scripted use then I can't see this being a problem but could be re-factored to run asynchronously and give CLI feedback of download progress if required (although it's still only 15Mb so should be quick for anyone).