### PR TITLE
Option to create Separate file for every Audio Source

### DIFF
--- a/src/Captura.Base/Audio/AudioSource.cs
+++ b/src/Captura.Base/Audio/AudioSource.cs
@@ -30,6 +30,8 @@ namespace Captura.Models
 
         protected abstract void OnRefresh();
 
-        public abstract IAudioProvider GetAudioProvider(int FrameRate);
+        public abstract IAudioProvider GetMixedAudioProvider(int FrameRate);
+
+        public abstract IAudioProvider[] GetMultipleAudioProviders();
     }
 }

--- a/src/Captura.Base/Settings/AudioSettings.cs
+++ b/src/Captura.Base/Settings/AudioSettings.cs
@@ -2,6 +2,12 @@
 {
     public class AudioSettings : PropertyStore
     {
+        public bool SeparateFilePerSource
+        {
+            get => Get(false);
+            set => Set(value);
+        }
+
         public bool Enabled
         {
             get => Get(false);

--- a/src/Captura.Bass/BassAudioProvider.cs
+++ b/src/Captura.Bass/BassAudioProvider.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using ManagedBass;
+using System.Runtime.InteropServices;
+using Wf = Captura.Audio.WaveFormat;
+using Captura.Audio;
+
+namespace Captura.Models
+{
+    class BassAudioProvider : IAudioProvider
+    {
+        readonly int _recordingHandle;
+
+        readonly int _silenceHandle;
+ 
+        readonly object _syncLock = new object();
+
+        public BassAudioProvider(BassItem Device)
+        {
+            if (Device == null)
+                throw new ArgumentNullException();
+
+            Bass.RecordInit(Device.Id);
+
+            var devInfo = Bass.RecordGetDeviceInfo(Device.Id);
+
+            if (devInfo.IsLoopback)
+            {
+                var playbackDevice = FindPlaybackDevice(devInfo);
+
+                if (playbackDevice != -1)
+                {
+                    Bass.Init(playbackDevice);
+                    Bass.CurrentDevice = playbackDevice;
+
+                    _silenceHandle = Bass.CreateStream(44100, 2, BassFlags.Default, Extensions.SilenceStreamProcedure);
+
+                    Bass.ChannelSetAttribute(_silenceHandle, ChannelAttribute.Volume, 0);
+                }
+            }
+
+            Bass.CurrentRecordingDevice = Device.Id;
+
+            var info = Bass.RecordingInfo;
+
+            _recordingHandle = Bass.RecordStart(info.Frequency, info.Channels, BassFlags.RecordPause, RecordProcedure);
+        }
+
+        bool RecordProcedure(int Handle, IntPtr Ptr, int Length, IntPtr User)
+        {
+            var buffer = GetBuffer(Length);
+
+            Marshal.Copy(Ptr, buffer, 0, Length);
+
+            DataAvailable?.Invoke(this, new DataAvailableEventArgs(buffer, Length));
+
+            return true;
+        }
+
+        static int FindPlaybackDevice(DeviceInfo LoopbackDeviceInfo)
+        {
+            for (var i = 0; Bass.GetDeviceInfo(i, out var info); ++i)
+            {
+                if (info.Driver == LoopbackDeviceInfo.Driver)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        byte[] _buffer;
+
+        byte[] GetBuffer(int Length)
+        {
+            if (_buffer == null || _buffer.Length < Length)
+            {
+                _buffer = new byte[Length + 1000];
+
+                Console.WriteLine($"New Audio Buffer Allocated: {Length}");
+            }
+
+            return _buffer;
+        }
+        
+        /// <summary>
+        /// Gets the WaveFormat of this <see cref="IAudioProvider"/>.
+        /// </summary>
+        public Wf WaveFormat => new Wf(44100, 16, 2);
+
+        /// <summary>
+        /// Indicates recorded data is available.
+        /// </summary>
+        public event EventHandler<DataAvailableEventArgs> DataAvailable;
+        
+        /// <summary>
+        /// Frees up the resources used by this instant.
+        /// </summary>
+        public void Dispose()
+        {
+            lock (_syncLock)
+            {
+                Bass.StreamFree(_recordingHandle);
+
+                if (_silenceHandle != 0)
+                    Bass.StreamFree(_silenceHandle);
+            }
+        }
+
+        /// <summary>
+        /// Start Recording.
+        /// </summary>
+        public void Start()
+        {
+            lock (_syncLock)
+            {
+                if (_silenceHandle != 0)
+                    Bass.ChannelPlay(_silenceHandle);
+
+                Bass.ChannelPlay(_recordingHandle);
+            }
+        }
+
+        /// <summary>
+        /// Stop Recording.
+        /// </summary>
+        public void Stop()
+        {
+            lock (_syncLock)
+            {
+                Bass.ChannelPause(_recordingHandle);
+
+                if (_silenceHandle != 0)
+                    Bass.ChannelPause(_silenceHandle);
+            }
+        }
+    }
+}

--- a/src/Captura.Bass/BassAudioSource.cs
+++ b/src/Captura.Bass/BassAudioSource.cs
@@ -34,7 +34,7 @@ namespace Captura.Models
         // Check if all BASS dependencies are present
         public static bool Available { get; } = AllExist("ManagedBass.dll", "ManagedBass.Mix.dll", "bass.dll", "bassmix.dll");
 
-        public override IAudioProvider GetAudioProvider(int FrameRate)
+        public override IAudioProvider GetMixedAudioProvider(int FrameRate)
         {
             return new MixedAudioProvider(AvailableRecordingSources
                 .Concat(AvailableLoopbackSources)
@@ -42,6 +42,15 @@ namespace Captura.Models
                 FrameRate,
                 !_settings.PlaybackRecordingRealTime
                 );
+        }
+
+        public override IAudioProvider[] GetMultipleAudioProviders()
+        {
+            return AvailableRecordingSources
+                .Concat(AvailableLoopbackSources)
+                .Cast<BassItem>()
+                .Select(M => new BassAudioProvider(M))
+                .ToArray<IAudioProvider>();
         }
 
         protected override void OnRefresh()

--- a/src/Captura.Bass/BassAudioSource.cs
+++ b/src/Captura.Bass/BassAudioSource.cs
@@ -46,8 +46,8 @@ namespace Captura.Models
 
         public override IAudioProvider[] GetMultipleAudioProviders()
         {
-            return AvailableRecordingSources
-                .Concat(AvailableLoopbackSources)
+            return AvailableRecordingSources.Where(M => M.Active)
+                .Concat(AvailableLoopbackSources.Where(M => M.Active))
                 .Cast<BassItem>()
                 .Select(M => new BassAudioProvider(M))
                 .ToArray<IAudioProvider>();

--- a/src/Captura.Bass/Captura.Bass.csproj
+++ b/src/Captura.Bass/Captura.Bass.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="BassAudioSource.cs" />
     <Compile Include="BassItem.cs" />
+    <Compile Include="BassAudioProvider.cs" />
     <Compile Include="MixedAudioProvider.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Captura.Core/Models/NoAudioSource.cs
+++ b/src/Captura.Core/Models/NoAudioSource.cs
@@ -8,7 +8,8 @@ namespace Captura.Models
     // ReSharper disable once ClassNeverInstantiated.Global
     public class NoAudioSource : AudioSource
     {
-        public override IAudioProvider GetAudioProvider(int FrameRate) => null;
+        public override IAudioProvider GetMixedAudioProvider(int FrameRate) => null;
+        public override IAudioProvider[] GetMultipleAudioProviders() => new IAudioProvider[0];
 
         protected override void OnRefresh() { }
     }

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -350,21 +350,23 @@ namespace Captura.ViewModels
                         {
                             if (Settings.Audio.SeparateFilePerSource)
                             {
-                                var index = 0;
-
-                                string GetAudioFileName()
+                                string GetAudioFileName(int Index)
                                 {
-                                    return Path.ChangeExtension(_currentFileName, $".{index++}{Path.GetExtension(_currentFileName)}");
+                                    return Path.ChangeExtension(_currentFileName, $".{Index}{Path.GetExtension(_currentFileName)}");
                                 }
 
                                 var audioProviders = _audioSource.GetMultipleAudioProviders();
 
                                 if (audioProviders.Length > 0)
                                 {
-                                    var recorders = audioProviders.Select(M => GetAudioRecorder(M, GetAudioFileName()))
+                                    var recorders = audioProviders
+                                        .Select((M, Index) => GetAudioRecorder(M, GetAudioFileName(Index)))
                                         .ToArray();
 
                                     _recorder = new MultiRecorder(recorders);
+
+                                    // Set to first file
+                                    _currentFileName = GetAudioFileName(0);
                                 }
                                 else
                                 {

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -102,7 +102,7 @@ namespace Captura.ViewModels
             }
         }
 
-        bool _canChangeWebcam = true;
+        bool _canChangeWebcam = true, _canChangeAudioSources = true;
 
         public bool CanChangeWebcam
         {
@@ -111,6 +111,17 @@ namespace Captura.ViewModels
             {
                 _canChangeWebcam = value;
 
+                OnPropertyChanged();
+            }
+        }
+
+        public bool CanChangeAudioSources
+        {
+            get => _canChangeAudioSources;
+            set
+            {
+                _canChangeAudioSources = value;
+                
                 OnPropertyChanged();
             }
         }
@@ -277,7 +288,7 @@ namespace Captura.ViewModels
 
             try
             {
-                if (Settings.Audio.Enabled)
+                if (Settings.Audio.Enabled && !Settings.Audio.SeparateFilePerSource)
                 {
                     audioProvider = _audioSource.GetMixedAudioProvider(Settings.Video.FrameRate);
                 }
@@ -354,6 +365,7 @@ namespace Captura.ViewModels
             RecorderState = RecorderState.Recording;
 
             CanChangeWebcam = !Settings.WebcamOverlay.SeparateFile;
+            CanChangeAudioSources = !Settings.Audio.SeparateFilePerSource;
 
             _timer?.Stop();
             TimeSpan = TimeSpan.Zero;
@@ -403,7 +415,7 @@ namespace Captura.ViewModels
         {
             RecorderState = RecorderState.NotRecording;
 
-            CanChangeWebcam = true;
+            CanChangeWebcam = CanChangeAudioSources = true;
 
             _recorder = null;
 

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -279,7 +279,7 @@ namespace Captura.ViewModels
             {
                 if (Settings.Audio.Enabled)
                 {
-                    audioProvider = _audioSource.GetAudioProvider(Settings.Video.FrameRate);
+                    audioProvider = _audioSource.GetMixedAudioProvider(Settings.Video.FrameRate);
                 }
             }
             catch (Exception e)

--- a/src/Captura/Pages/ExtrasPage.xaml
+++ b/src/Captura/Pages/ExtrasPage.xaml
@@ -23,6 +23,10 @@
                       Content="Record Webcam to separate file"
                       Margin="0,5"/>
 
+            <CheckBox IsChecked="{Binding Settings.Audio.SeparateFilePerSource}"
+                      Content="Separate files for every audio source"
+                      Margin="0,5"/>
+
             <Grid Margin="0,5">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>

--- a/src/Captura/Pages/ExtrasPage.xaml
+++ b/src/Captura/Pages/ExtrasPage.xaml
@@ -13,6 +13,7 @@
 
             <CheckBox IsChecked="{Binding Settings.Audio.PlaybackRecordingRealTime}"
                       Content="Playback recorded audio in real-time"
+                      IsEnabled="{Binding Settings.Audio.SeparateFilePerSource, Converter={StaticResource NegatingConverter}}"
                       Margin="0,5"/>
             
             <CheckBox IsChecked="{Binding Settings.Video.FpsLimit, Converter={StaticResource NegatingConverter}}"

--- a/src/Captura/Pages/MainPage.xaml
+++ b/src/Captura/Pages/MainPage.xaml
@@ -244,7 +244,7 @@
         
         <ScrollViewer Height="90"
                       IsEnabled="{Binding Settings.Audio.Enabled}">
-            <StackPanel>
+            <StackPanel IsEnabled="{Binding RecordingViewModel.CanChangeAudioSources}">
                 <ItemsControl ItemsSource="{Binding AudioSource.AvailableRecordingSources}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>


### PR DESCRIPTION
Related to #234 

Can be enabled at `Config / Extras`.
Audio Sources cannot be changed during recording if this option is enabled.
Playback Recorded audio in real-time option does not work with this option.

Files are named as `[FILE NAME].[INDEX].[EXTENSION]`. Index starts from 0.

### Audio only recording
Only the first file is added to the recent list.

### Video + Audio recording
Audio files are not added to recent list.
Audio files are in Wave format (`.wav`).

---

Changed Webcam separate file naming to `.webcam` from `-webcam` for consistency.