### PR TITLE
GPU accelerated encoding

### DIFF
--- a/src/Captura.Core/Captura.Core.csproj
+++ b/src/Captura.Core/Captura.Core.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/Captura.Core/CoreModule.cs
+++ b/src/Captura.Core/CoreModule.cs
@@ -1,5 +1,6 @@
 ﻿using Captura.Models;
 using Captura.ViewModels;
+using DesktopDuplication;
 
 namespace Captura
 {
@@ -7,6 +8,8 @@ namespace Captura
     {
         public void OnLoad(IBinder Binder)
         {
+            MfManager.Startup();
+
             // Singleton View Models
             Binder.BindSingleton<MainViewModel>();
             Binder.BindSingleton<VideoViewModel>();

--- a/src/Captura.Core/ViewModels/MainViewModel.cs
+++ b/src/Captura.Core/ViewModels/MainViewModel.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Input;
+using DesktopDuplication;
 
 namespace Captura.ViewModels
 {
@@ -297,6 +298,8 @@ namespace Captura.ViewModels
 
                 Settings.Save();
             }
+
+            MfManager.Shutdown();
         }
         
         void CheckFunctionalityAvailability()

--- a/src/Captura.Core/ViewModels/MainViewModel.cs
+++ b/src/Captura.Core/ViewModels/MainViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using Captura.Models;
-using Screna;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -10,6 +10,7 @@ using System.Timers;
 using Captura.Audio;
 using Captura.Models;
 using Captura.Webcam;
+using DesktopDuplication;
 using Microsoft.Win32;
 using Screna;
 using Timer = System.Timers.Timer;
@@ -425,6 +426,8 @@ namespace Captura.ViewModels
                     _recorder = new MultiRecorder(recorders);
                 }
             }
+
+            _recorder = (ServiceProvider.Get<DeskDuplSourceProvider>().First() as DeskDuplItem).GetRecorder(Settings.Video.FrameRate);
 
             if (_videoViewModel.SelectedVideoSourceKind is RegionSourceProvider)
                 _regionProvider.Lock();

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -427,7 +427,7 @@ namespace Captura.ViewModels
                 }
             }
 
-            _recorder = (ServiceProvider.Get<DeskDuplSourceProvider>().First() as DeskDuplItem).GetRecorder(Settings.Video.FrameRate);
+            _recorder = (ServiceProvider.Get<DeskDuplSourceProvider>().First() as DeskDuplItem).GetRecorder(Settings.Video.FrameRate, _currentFileName);
 
             if (_videoViewModel.SelectedVideoSourceKind is RegionSourceProvider)
                 _regionProvider.Lock();

--- a/src/Captura.Core/app.config
+++ b/src/Captura.Core/app.config
@@ -1,11 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-  </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <probing privatePath="lib" />
       <dependentAssembly>
         <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />

--- a/src/Captura/app.config
+++ b/src/Captura/app.config
@@ -5,7 +5,15 @@
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <probing privatePath="lib"/>
+      <probing privatePath="lib" />
+      <dependentAssembly>
+        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SharpDX.DXGI" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/DesktopDuplication/AllocatedTexture.cs
+++ b/src/DesktopDuplication/AllocatedTexture.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using SharpDX.Direct3D11;
+using SharpDX.MediaFoundation;
+
+namespace DesktopDuplication
+{
+    public class AllocatedTexture : IDisposable
+    {
+        static readonly Guid D3D11Texture2D = new Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
+
+        readonly MediaBuffer _mediaBuffer;
+
+        public AllocatedTexture(Texture2D Texture)
+        {
+            this.Texture = Texture;
+
+            Sample = CreateSample(Texture, out _mediaBuffer);
+        }
+
+        static Sample CreateSample(Texture2D Texture, out MediaBuffer MediaBuffer)
+        {
+            // Create the video sample. This function returns an IMFTrackedSample per MSDN
+            var sample = MediaFactory.CreateVideoSampleFromSurface(null);
+
+            // Query the IMFSample to see if it implements IMFTrackedSample
+            //var trackedSample = sample.QueryInterface<TrackedSample>();
+
+            // Create the media buffer from the texture
+            MediaFactory.CreateDXGISurfaceBuffer(D3D11Texture2D, Texture, 0, false, out MediaBuffer);
+
+            // Set the owning instance of this class as the allocator
+            // for IMFTrackedSample to notify when the sample is released
+            //trackedSample.SetAllocator(this, null);
+
+            MediaBuffer.CurrentLength = MediaBuffer.QueryInterface<Buffer2D>().ContiguousLength;
+
+            // Attach the created buffer to the sample
+            sample.AddBuffer(MediaBuffer);
+            return sample;
+        }
+
+        public Texture2D Texture { get; }
+        public Sample Sample { get; }
+
+        public void Dispose()
+        {
+            Sample.RemoveAllBuffers();
+
+            _mediaBuffer.Dispose();
+
+            Sample.Dispose();
+
+            Texture.Dispose();
+        }
+    }
+}

--- a/src/DesktopDuplication/DeskDuplItem.cs
+++ b/src/DesktopDuplication/DeskDuplItem.cs
@@ -46,7 +46,10 @@ namespace Captura.Models
             var rect = Rectangle;
             rect.Location = Point.Empty;
 
-            var deskDuplProvider = new DeskDuplMediaFoundation(rect, _adapter, _output, Fps, FileName);
+            var deskDuplProvider = new DeskDuplMediaFoundation(rect, _adapter, _output, Fps, FileName)
+            {
+                Timeout = 500
+            };
 
             return new DeskDuplMfRecorder(deskDuplProvider);
         }

--- a/src/DesktopDuplication/DeskDuplItem.cs
+++ b/src/DesktopDuplication/DeskDuplItem.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Drawing;
+using DesktopDuplication;
+using Screna;
 using SharpDX.DXGI;
 
 namespace Captura.Models
@@ -34,9 +36,19 @@ namespace Captura.Models
             var rect = Rectangle;
             rect.Location = Point.Empty;
 
-            Transform = P => new Point(P.X - rect.Left, P.Y - rect.Top);
+            Transform = P => P;
 
             return new DeskDuplImageProvider(_adapter, _output, rect, IncludeCursor);
+        }
+
+        public IRecorder GetRecorder(int Fps)
+        {
+            var rect = Rectangle;
+            rect.Location = Point.Empty;
+
+            var deskDuplProvider = new DeskDuplMediaFoundation(rect, _adapter, _output, Fps);
+
+            return new DeskDuplMfRecorder(deskDuplProvider);
         }
     }
 }

--- a/src/DesktopDuplication/DeskDuplItem.cs
+++ b/src/DesktopDuplication/DeskDuplItem.cs
@@ -41,12 +41,12 @@ namespace Captura.Models
             return new DeskDuplImageProvider(_adapter, _output, rect, IncludeCursor);
         }
 
-        public IRecorder GetRecorder(int Fps)
+        public IRecorder GetRecorder(int Fps, string FileName)
         {
             var rect = Rectangle;
             rect.Location = Point.Empty;
 
-            var deskDuplProvider = new DeskDuplMediaFoundation(rect, _adapter, _output, Fps);
+            var deskDuplProvider = new DeskDuplMediaFoundation(rect, _adapter, _output, Fps, FileName);
 
             return new DeskDuplMfRecorder(deskDuplProvider);
         }

--- a/src/DesktopDuplication/DeskDuplMediaFoundation.cs
+++ b/src/DesktopDuplication/DeskDuplMediaFoundation.cs
@@ -14,11 +14,8 @@ namespace DesktopDuplication
         #region Fields
         readonly Device _device;
         readonly OutputDuplication _deskDupl;
-        OutputDuplicateFrameInformation _frameInfo;
 
         Rectangle _rect;
-
-        readonly bool _includeCursor;
         #endregion
 
         public int Timeout { get; set; }
@@ -26,15 +23,17 @@ namespace DesktopDuplication
         readonly TextureAllocator _textureAllocator;
         readonly MfWriter _writer;
 
-        public DeskDuplMediaFoundation(Rectangle Rect, bool IncludeCursor, Adapter Adapter, Output1 Output)
+        public int Fps { get; }
+
+        public DeskDuplMediaFoundation(Rectangle Rect, Adapter Adapter, Output1 Output, int Fps)
         {
             MfManager.Startup();
 
             _rect = Rect;
-            _includeCursor = IncludeCursor;
+            this.Fps = Fps;
             
-            _device = new Device(Adapter);
-            _writer = new MfWriter(_device, 30, _rect.Width, _rect.Height);
+            _device = new Device(Adapter, DeviceCreationFlags.VideoSupport);
+            _writer = new MfWriter(_device, Fps, _rect.Width, _rect.Height);
 
             var textureDesc = new Texture2DDescription
             {
@@ -72,7 +71,7 @@ namespace DesktopDuplication
 
             try
             {
-                _deskDupl.AcquireNextFrame(Timeout, out _frameInfo, out desktopResource);
+                _deskDupl.AcquireNextFrame(Timeout, out var frameInfo, out desktopResource);
             }
             catch (SharpDXException e) when (e.Descriptor == SharpDX.DXGI.ResultCode.WaitTimeout)
             {

--- a/src/DesktopDuplication/DeskDuplMediaFoundation.cs
+++ b/src/DesktopDuplication/DeskDuplMediaFoundation.cs
@@ -84,7 +84,7 @@ namespace DesktopDuplication
             if (!AcquireFrame(out var desktopResource))
                 return;
 
-            var texture = _textureAllocator.AllocateTexture();
+            var allocatedTexture = _textureAllocator.AllocateTexture();
             
             using (desktopResource)
             {
@@ -92,7 +92,7 @@ namespace DesktopDuplication
                 {
                     var resourceRegion = new ResourceRegion(_rect.Left, _rect.Top, 0, _rect.Right, _rect.Bottom, 1);
 
-                    _device.ImmediateContext.CopySubresourceRegion(tempTexture, 0, resourceRegion, texture, 0);
+                    _device.ImmediateContext.CopySubresourceRegion(tempTexture, 0, resourceRegion, allocatedTexture.Texture, 0);
                 }
             }
 
@@ -106,9 +106,7 @@ namespace DesktopDuplication
 
             _writeTask = Task.Run(() =>
             {
-                var sample = _textureAllocator.CreateSample(texture);
-
-                _writer.Write(sample);
+                _writer.Write(allocatedTexture.Sample);
             });
         }
 

--- a/src/DesktopDuplication/DeskDuplMediaFoundation.cs
+++ b/src/DesktopDuplication/DeskDuplMediaFoundation.cs
@@ -26,7 +26,7 @@ namespace DesktopDuplication
 
         public int Fps { get; }
 
-        public DeskDuplMediaFoundation(Rectangle Rect, Adapter Adapter, Output1 Output, int Fps)
+        public DeskDuplMediaFoundation(Rectangle Rect, Adapter Adapter, Output1 Output, int Fps, string FileName)
         {
             MfManager.Startup();
 
@@ -34,7 +34,7 @@ namespace DesktopDuplication
             this.Fps = Fps;
             
             _device = new Device(Adapter, DeviceCreationFlags.VideoSupport);
-            _writer = new MfWriter(_device, Fps, _rect.Width, _rect.Height);
+            _writer = new MfWriter(_device, Fps, _rect.Width, _rect.Height, FileName);
 
             var textureDesc = new Texture2DDescription
             {

--- a/src/DesktopDuplication/DeskDuplMediaFoundation.cs
+++ b/src/DesktopDuplication/DeskDuplMediaFoundation.cs
@@ -1,0 +1,134 @@
+﻿// Adapted from https://github.com/jasonpang/desktop-duplication-net
+
+using SharpDX;
+using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using System;
+using Device = SharpDX.Direct3D11.Device;
+using Rectangle = System.Drawing.Rectangle;
+
+namespace DesktopDuplication
+{
+    public class DeskDuplMediaFoundation : IDisposable
+    {
+        #region Fields
+        readonly Device _device;
+        readonly OutputDuplication _deskDupl;
+        OutputDuplicateFrameInformation _frameInfo;
+
+        Rectangle _rect;
+
+        readonly bool _includeCursor;
+        #endregion
+
+        public int Timeout { get; set; }
+
+        readonly TextureAllocator _textureAllocator;
+        readonly MfWriter _writer;
+
+        public DeskDuplMediaFoundation(Rectangle Rect, bool IncludeCursor, Adapter Adapter, Output1 Output)
+        {
+            MfManager.Startup();
+
+            _rect = Rect;
+            _includeCursor = IncludeCursor;
+            
+            _device = new Device(Adapter);
+            _writer = new MfWriter(_device, 30, _rect.Width, _rect.Height);
+
+            var textureDesc = new Texture2DDescription
+            {
+                CpuAccessFlags = CpuAccessFlags.Read,
+                BindFlags = BindFlags.None,
+                Format = Format.B8G8R8A8_UNorm,
+                Width = _rect.Width,
+                Height = _rect.Height,
+                OptionFlags = ResourceOptionFlags.None,
+                MipLevels = 1,
+                ArraySize = 1,
+                SampleDescription = {Count = 1, Quality = 0},
+                Usage = ResourceUsage.Staging
+            };
+
+            _textureAllocator = new TextureAllocator(textureDesc, _device);
+            
+            try
+            {
+                _deskDupl = Output.DuplicateOutput(_device);
+            }
+            catch (SharpDXException e) when (e.Descriptor == SharpDX.DXGI.ResultCode.NotCurrentlyAvailable)
+            {
+                throw new Exception("There is already the maximum number of applications using the Desktop Duplication API running, please close one of the applications and try again.", e);
+            }
+            catch (SharpDXException e) when (e.Descriptor == SharpDX.DXGI.ResultCode.Unsupported)
+            {
+                throw new NotSupportedException("Desktop Duplication is not supported on this system.\nIf you have multiple graphic cards, try running Captura on integrated graphics.", e);
+            }
+        }
+        
+        public void Capture()
+        {
+            SharpDX.DXGI.Resource desktopResource;
+
+            try
+            {
+                _deskDupl.AcquireNextFrame(Timeout, out _frameInfo, out desktopResource);
+            }
+            catch (SharpDXException e) when (e.Descriptor == SharpDX.DXGI.ResultCode.WaitTimeout)
+            {
+                return;
+            }
+            catch (SharpDXException e) when (e.ResultCode.Failure)
+            {
+                throw new Exception("Failed to acquire next frame.", e);
+            }
+
+            var texture = _textureAllocator.AllocateTexture();
+            
+            using (desktopResource)
+            {
+                using (var tempTexture = desktopResource.QueryInterface<Texture2D>())
+                {
+                    var resourceRegion = new ResourceRegion(_rect.Left, _rect.Top, 0, _rect.Right, _rect.Bottom, 1);
+
+                    _device.ImmediateContext.CopySubresourceRegion(tempTexture, 0, resourceRegion, texture, 0);
+                }
+            }
+
+            ReleaseFrame();
+
+            var sample = _textureAllocator.CreateSample(texture);
+
+            _writer.Write(sample);
+        }
+        
+        void ReleaseFrame()
+        {
+            try
+            {
+                _deskDupl.ReleaseFrame();
+            }
+            catch (SharpDXException e)
+            {
+                if (e.ResultCode.Failure)
+                {
+                    throw new Exception("Failed to release frame.", e);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _deskDupl?.Dispose();
+                _device?.Dispose();
+
+                _textureAllocator.Dispose();
+
+                MfManager.Shutdown();
+            }
+            catch { }
+        }
+    }
+}

--- a/src/DesktopDuplication/DeskDuplMediaFoundation.cs
+++ b/src/DesktopDuplication/DeskDuplMediaFoundation.cs
@@ -30,7 +30,7 @@ namespace DesktopDuplication
         public int Fps { get; }
 
         DateTime _lastAcquireTime;
-        int _frameIntervalMs;
+        readonly int _frameIntervalMs;
 
         public DeskDuplMediaFoundation(Rectangle Rect, Adapter Adapter, Output1 Output, int Fps, string FileName)
         {
@@ -102,6 +102,8 @@ namespace DesktopDuplication
                     ReleaseFrame();
             }
 
+            _writeTask?.Wait();
+
             _writeTask = Task.Run(() =>
             {
                 var sample = _textureAllocator.CreateSample(texture);
@@ -111,8 +113,6 @@ namespace DesktopDuplication
         }
 
         Task _writeTask;
-
-        double _minms = 10000000;
 
         bool AcquireFrame(out Resource DesktopResource)
         {
@@ -208,8 +208,6 @@ namespace DesktopDuplication
                 }
             }
             catch { }
-
-            Console.WriteLine(_minms);
         }
     }
 }

--- a/src/DesktopDuplication/DeskDuplMediaFoundation.cs
+++ b/src/DesktopDuplication/DeskDuplMediaFoundation.cs
@@ -14,7 +14,8 @@ namespace DesktopDuplication
     {
         #region Fields
         readonly Device _device;
-        readonly OutputDuplication _deskDupl;
+        readonly Output1 _output;
+        OutputDuplication _deskDupl;
 
         Rectangle _rect;
         #endregion
@@ -31,6 +32,7 @@ namespace DesktopDuplication
             MfManager.Startup();
 
             _rect = Rect;
+            _output = Output;
             this.Fps = Fps;
             
             _device = new Device(Adapter, DeviceCreationFlags.VideoSupport);
@@ -51,9 +53,16 @@ namespace DesktopDuplication
 
             _textureAllocator = new TextureAllocator(textureDesc, _device);
             
+            ReInit();
+        }
+
+        void ReInit()
+        {
+            _deskDupl?.Dispose();
+
             try
             {
-                _deskDupl = Output.DuplicateOutput(_device);
+                _deskDupl = _output.DuplicateOutput(_device);
             }
             catch (SharpDXException e) when (e.Descriptor == SharpDX.DXGI.ResultCode.NotCurrentlyAvailable)
             {
@@ -79,7 +88,9 @@ namespace DesktopDuplication
             }
             catch (SharpDXException e) when (e.ResultCode.Failure)
             {
-                throw new Exception("Failed to acquire next frame.", e);
+                ReInit();
+                return;
+                //throw new Exception("Failed to acquire next frame.", e);
             }
 
             var texture = _textureAllocator.AllocateTexture();

--- a/src/DesktopDuplication/DeskDuplMediaFoundation.cs
+++ b/src/DesktopDuplication/DeskDuplMediaFoundation.cs
@@ -4,6 +4,7 @@ using SharpDX;
 using SharpDX.Direct3D11;
 using SharpDX.DXGI;
 using System;
+using SharpDX.Direct3D;
 using Device = SharpDX.Direct3D11.Device;
 using Rectangle = System.Drawing.Rectangle;
 
@@ -37,7 +38,7 @@ namespace DesktopDuplication
 
             var textureDesc = new Texture2DDescription
             {
-                CpuAccessFlags = CpuAccessFlags.Read,
+                CpuAccessFlags = CpuAccessFlags.None,
                 BindFlags = BindFlags.None,
                 Format = Format.B8G8R8A8_UNorm,
                 Width = _rect.Width,
@@ -45,8 +46,7 @@ namespace DesktopDuplication
                 OptionFlags = ResourceOptionFlags.None,
                 MipLevels = 1,
                 ArraySize = 1,
-                SampleDescription = {Count = 1, Quality = 0},
-                Usage = ResourceUsage.Staging
+                SampleDescription = {Count = 1, Quality = 0}
             };
 
             _textureAllocator = new TextureAllocator(textureDesc, _device);
@@ -122,6 +122,8 @@ namespace DesktopDuplication
             {
                 _deskDupl?.Dispose();
                 _device?.Dispose();
+
+                _writer.Dispose();
 
                 _textureAllocator.Dispose();
 

--- a/src/DesktopDuplication/DeskDuplMfRecorder.cs
+++ b/src/DesktopDuplication/DeskDuplMfRecorder.cs
@@ -43,10 +43,10 @@ namespace Screna
             if (!ErrorOccurred)
                 _recordTask.Wait();
 
+            _deskDupl.Dispose();
+
             _continueCapturing.Dispose();
             _stopCapturing.Dispose();
-
-            _deskDupl.Dispose();
         }
 
         /// <summary>

--- a/src/DesktopDuplication/DeskDuplMfRecorder.cs
+++ b/src/DesktopDuplication/DeskDuplMfRecorder.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Captura;
+using DesktopDuplication;
+
+namespace Screna
+{
+    public class DeskDuplMfRecorder : IRecorder
+    {
+        #region Fields
+        readonly DeskDuplMediaFoundation _deskDupl;
+
+        readonly Task _recordTask;
+
+        readonly ManualResetEvent _stopCapturing = new ManualResetEvent(false),
+            _continueCapturing = new ManualResetEvent(false);
+        #endregion
+        
+        public DeskDuplMfRecorder(DeskDuplMediaFoundation DeskDupl)
+        {
+            _deskDupl = DeskDupl;
+
+            // Not Actually Started, Waits for _continueCapturing to be Set
+            _recordTask = Task.Factory.StartNew(async () => await Record());
+        }
+
+        /// <summary>
+        /// Start recording.
+        /// </summary>
+        public void Start()
+        {
+            _continueCapturing.Set();
+        }
+
+        void Dispose(bool ErrorOccurred)
+        {
+            // Resume if Paused
+            _continueCapturing.Set();
+            
+            _stopCapturing.Set();
+
+            if (!ErrorOccurred)
+                _recordTask.Wait();
+
+            _continueCapturing.Dispose();
+            _stopCapturing.Dispose();
+
+            _deskDupl.Dispose();
+        }
+
+        /// <summary>
+        /// Frees resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Override this method with the code to pause recording.
+        /// </summary>
+        public void Stop()
+        {
+            _continueCapturing.Reset();
+        }
+
+        async Task Record()
+        {
+            var frameInterval = TimeSpan.FromSeconds(1.0 / _deskDupl.Fps);
+
+            try
+            {
+                Task task = null;
+
+                while (!_stopCapturing.WaitOne(0) && _continueCapturing.WaitOne())
+                {
+                    var timestamp = DateTime.Now;
+
+                    if (task != null)
+                    {
+                        await task;
+                    }
+
+                    task = Task.Factory.StartNew(() => _deskDupl.Capture());
+
+                    var timeTillNextFrame = timestamp + frameInterval - DateTime.Now;
+
+                    if (timeTillNextFrame > TimeSpan.Zero)
+                        Thread.Sleep(timeTillNextFrame);
+                }
+            }
+            catch (Exception e)
+            {
+                ErrorOccurred?.Invoke(e);
+
+                Dispose(true);
+            }
+        }
+
+        /// <summary>
+        /// Fired when an Error occurs.
+        /// </summary>
+        public event Action<Exception> ErrorOccurred;
+    }
+}

--- a/src/DesktopDuplication/DesktopDuplication.csproj
+++ b/src/DesktopDuplication/DesktopDuplication.csproj
@@ -35,8 +35,17 @@
     <Reference Include="SharpDX.Direct3D11, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.Direct3D11.4.1.0\lib\net45\SharpDX.Direct3D11.dll</HintPath>
     </Reference>
+    <Reference Include="SharpDX.Direct3D9, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Direct3D9.4.1.0\lib\net45\SharpDX.Direct3D9.dll</HintPath>
+    </Reference>
     <Reference Include="SharpDX.DXGI, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.DXGI.4.1.0\lib\net45\SharpDX.DXGI.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.Mathematics, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Mathematics.4.1.0\lib\net45\SharpDX.Mathematics.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.MediaFoundation, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.MediaFoundation.4.1.0\lib\net45\SharpDX.MediaFoundation.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/DesktopDuplication/DesktopDuplication.csproj
+++ b/src/DesktopDuplication/DesktopDuplication.csproj
@@ -54,7 +54,11 @@
     <Compile Include="DeskDuplImageProvider.cs" />
     <Compile Include="DeskDuplItem.cs" />
     <Compile Include="DeskDuplSourceProvider.cs" />
+    <Compile Include="DeskDuplMediaFoundation.cs" />
     <Compile Include="DesktopDuplicator.cs" />
+    <Compile Include="MfManager.cs" />
+    <Compile Include="MfWriter.cs" />
+    <Compile Include="TextureAllocator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/DesktopDuplication/DesktopDuplication.csproj
+++ b/src/DesktopDuplication/DesktopDuplication.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AllocatedTexture.cs" />
     <Compile Include="DeskDuplImageProvider.cs" />
     <Compile Include="DeskDuplItem.cs" />
     <Compile Include="DeskDuplSourceProvider.cs" />

--- a/src/DesktopDuplication/DesktopDuplication.csproj
+++ b/src/DesktopDuplication/DesktopDuplication.csproj
@@ -29,23 +29,23 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SharpDX, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.4.1.0\lib\net45\SharpDX.dll</HintPath>
+    <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.4.2.0-ci259\lib\net45\SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.Direct3D11, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.Direct3D11.4.1.0\lib\net45\SharpDX.Direct3D11.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Direct3D9, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Direct3D9.4.1.0\lib\net45\SharpDX.Direct3D9.dll</HintPath>
+    <Reference Include="SharpDX.Direct3D9, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Direct3D9.4.2.0-ci259\lib\net45\SharpDX.Direct3D9.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.DXGI, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.DXGI.4.1.0\lib\net45\SharpDX.DXGI.dll</HintPath>
+    <Reference Include="SharpDX.DXGI, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.DXGI.4.2.0-ci259\lib\net45\SharpDX.DXGI.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Mathematics, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Mathematics.4.1.0\lib\net45\SharpDX.Mathematics.dll</HintPath>
+    <Reference Include="SharpDX.Mathematics, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Mathematics.4.2.0-ci259\lib\net45\SharpDX.Mathematics.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.MediaFoundation, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.MediaFoundation.4.1.0\lib\net45\SharpDX.MediaFoundation.dll</HintPath>
+    <Reference Include="SharpDX.MediaFoundation, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.MediaFoundation.4.2.0-ci259\lib\net45\SharpDX.MediaFoundation.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
@@ -59,8 +59,10 @@
     <Compile Include="MfManager.cs" />
     <Compile Include="MfWriter.cs" />
     <Compile Include="TextureAllocator.cs" />
+    <Compile Include="DeskDuplMfRecorder.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DesktopDuplication/DesktopDuplicator.cs
+++ b/src/DesktopDuplication/DesktopDuplicator.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 using Captura;
 using Device = SharpDX.Direct3D11.Device;
 using MapFlags = SharpDX.Direct3D11.MapFlags;
+using Rectangle = System.Drawing.Rectangle;
+using Point = System.Drawing.Point;
 
 namespace DesktopDuplication
 {

--- a/src/DesktopDuplication/MfManager.cs
+++ b/src/DesktopDuplication/MfManager.cs
@@ -2,7 +2,7 @@
 
 namespace DesktopDuplication
 {
-    static class MfManager
+    public static class MfManager
     {
         public static void Startup()
         {

--- a/src/DesktopDuplication/MfManager.cs
+++ b/src/DesktopDuplication/MfManager.cs
@@ -4,12 +4,9 @@ namespace DesktopDuplication
 {
     static class MfManager
     {
-        const int MfSdkVersion = 0x2;
-        const int MfApiVersion = 0x0070;
-
         public static void Startup()
         {
-            MediaFactory.Startup(MfSdkVersion << 16 | MfApiVersion, 0);
+            MediaManager.Startup();
         }
 
         public static void Shutdown()

--- a/src/DesktopDuplication/MfManager.cs
+++ b/src/DesktopDuplication/MfManager.cs
@@ -1,0 +1,20 @@
+﻿using SharpDX.MediaFoundation;
+
+namespace DesktopDuplication
+{
+    static class MfManager
+    {
+        const int MfSdkVersion = 0x2;
+        const int MfApiVersion = 0x0070;
+
+        public static void Startup()
+        {
+            MediaFactory.Startup(MfSdkVersion << 16 | MfApiVersion, 0);
+        }
+
+        public static void Shutdown()
+        {
+            MediaFactory.Shutdown();
+        }
+    }
+}

--- a/src/DesktopDuplication/MfWriter.cs
+++ b/src/DesktopDuplication/MfWriter.cs
@@ -39,8 +39,10 @@ namespace DesktopDuplication
 
         public MfWriter(Device Device, int Fps, int Width, int Height, string FileName)
         {
-            var attr = new MediaAttributes(3);
+            var attr = new MediaAttributes(5);
             attr.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
+            attr.Set(SinkWriterAttributeKeys.ReadwriteDisableConverters, 0);
+            attr.Set(TranscodeAttributeKeys.TranscodeContainertype, TranscodeContainerTypeGuids.Mpeg4);
             attr.Set(SinkWriterAttributeKeys.LowLatency, true);
 
             var devMan = new DXGIDeviceManager();

--- a/src/DesktopDuplication/MfWriter.cs
+++ b/src/DesktopDuplication/MfWriter.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using SharpDX.Direct3D11;
+using SharpDX.MediaFoundation;
+
+namespace DesktopDuplication
+{
+    public class MfWriter : IDisposable
+    {
+        const int BitRate = 800_000;
+        readonly Guid _encodingFormat = VideoFormatGuids.Mp4v;
+        readonly Guid _inputFormat = VideoFormatGuids.Rgb32;
+
+        long _prevFrameTicks;
+
+        readonly SinkWriter _writer;
+        readonly int _streamIndex;
+
+        static long ToLong(int Low, int High)
+        {
+            return (long)(((uint)Low) | (ulong)(High << 32));
+        }
+
+        public MfWriter(Device Device, int Fps, int Width, int Height)
+        {
+            var attr = new MediaAttributes(3);
+            attr.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
+            attr.Set(SinkWriterAttributeKeys.LowLatency, true);
+
+            var devMan = new DXGIDeviceManager();
+            MediaFactory.CreateDXGIDeviceManager(out var resetToken, devMan);
+            devMan.ResetDevice(Device);
+
+            attr.Set(SinkWriterAttributeKeys.D3DManager, devMan);
+
+            _writer = MediaFactory.CreateSinkWriterFromURL("output.mp4", null, attr);
+
+            using (var mediaTypeOut = new MediaType())
+            {
+                MediaFactory.CreateMediaType(mediaTypeOut);
+
+                mediaTypeOut.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+                mediaTypeOut.Set(MediaTypeAttributeKeys.Subtype, _encodingFormat);
+                mediaTypeOut.Set(MediaTypeAttributeKeys.AvgBitrate, BitRate);
+                mediaTypeOut.Set(MediaTypeAttributeKeys.InterlaceMode, (int) VideoInterlaceMode.Progressive);
+                mediaTypeOut.Set(MediaTypeAttributeKeys.FrameSize, ToLong(Width, Height));
+                mediaTypeOut.Set(MediaTypeAttributeKeys.FrameRate, ToLong(Fps * 1000, 1000));
+                mediaTypeOut.Set(MediaTypeAttributeKeys.PixelAspectRatio, ToLong(1, 1));
+
+                _writer.AddStream(mediaTypeOut, out _streamIndex);
+            }
+
+            using (var mediaTypeIn = new MediaType())
+            {
+                MediaFactory.CreateMediaType(mediaTypeIn);
+
+                mediaTypeIn.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+                mediaTypeIn.Set(MediaTypeAttributeKeys.Subtype, _inputFormat);
+                mediaTypeIn.Set(MediaTypeAttributeKeys.InterlaceMode, (int) VideoInterlaceMode.Progressive);
+                mediaTypeIn.Set(MediaTypeAttributeKeys.FrameSize, ToLong(Width, Height));
+                mediaTypeIn.Set(MediaTypeAttributeKeys.FrameRate, ToLong(Fps * 1000, 1000));
+                mediaTypeIn.Set(MediaTypeAttributeKeys.PixelAspectRatio, ToLong(1, 1));
+
+                _writer.SetInputMediaType(_streamIndex, mediaTypeIn, null);
+            }
+
+            _writer.BeginWriting();
+        }
+
+        bool _first = true;
+
+        public void Write(Sample Sample)
+        {
+            var nowTicks = DateTime.Now.Ticks;
+
+            if (_prevFrameTicks == 0)
+                _prevFrameTicks = nowTicks;
+
+            Sample.SetSampleTime(_prevFrameTicks);
+            Sample.SetSampleDuration(nowTicks - _prevFrameTicks);
+
+            _prevFrameTicks = nowTicks;
+
+            if (_first)
+            {
+                _writer.SendStreamTick(_streamIndex, nowTicks);
+
+                Sample.Set(SampleAttributeKeys.Discontinuity, true);
+
+                _first = false;
+            }
+
+            _writer.WriteSample(_streamIndex, Sample);
+        }
+
+        public void Dispose()
+        {
+            _writer.Dispose();
+        }
+    }
+}

--- a/src/DesktopDuplication/MfWriter.cs
+++ b/src/DesktopDuplication/MfWriter.cs
@@ -8,7 +8,7 @@ namespace DesktopDuplication
 {
     public class MfWriter : IDisposable
     {
-        const int BitRate = 1_000_000;
+        const int BitRate = 4_000_000;
         readonly Guid _encodingFormat = VideoFormatGuids.H264;
         readonly Guid _inputFormat = VideoFormatGuids.Rgb32;
 

--- a/src/DesktopDuplication/MfWriter.cs
+++ b/src/DesktopDuplication/MfWriter.cs
@@ -87,7 +87,10 @@ namespace DesktopDuplication
         {
             lock (_syncLock)
             {
-                var nowTicks = _stopwatch.ElapsedTicks;
+                if (_disposed)
+                    return;
+
+                var nowTicks = _stopwatch.Elapsed.Ticks;
 
                 if (_prevFrameTicks == 0)
                     _prevFrameTicks = nowTicks;
@@ -96,9 +99,6 @@ namespace DesktopDuplication
                 Sample.SampleDuration = nowTicks - _prevFrameTicks;
 
                 _prevFrameTicks = nowTicks;
-            
-                if (_disposed)
-                    return;
 
                 if (_first)
                 {

--- a/src/DesktopDuplication/MfWriter.cs
+++ b/src/DesktopDuplication/MfWriter.cs
@@ -17,9 +17,21 @@ namespace DesktopDuplication
         readonly SinkWriter _writer;
         readonly int _streamIndex;
 
-        static long PackLong(int Low, int High)
+        static long PackLong(int Left, int Right)
         {
-            return ((uint)Low << 32) | (uint)High;
+            //implicit conversion of left to a long
+            long res = Left;
+
+            //shift the bits creating an empty space on the right
+            // ex: 0x0000CFFF becomes 0xCFFF0000
+            res = (res << 32);
+
+            //combine the bits on the right with the previous value
+            // ex: 0xCFFF0000 | 0x0000ABCD becomes 0xCFFFABCD
+            res = res | (uint)Right; //uint first to prevent loss of signed bit
+
+            //return the combined result
+            return res;
         }
 
         public MfWriter(Device Device, int Fps, int Width, int Height)
@@ -49,8 +61,6 @@ namespace DesktopDuplication
 
             using (var mediaTypeIn = new MediaType())
             {
-                var mediaAttr = new MediaAttributes();
-
                 mediaTypeIn.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
                 mediaTypeIn.Set(MediaTypeAttributeKeys.Subtype, _inputFormat);
                 mediaTypeIn.Set(MediaTypeAttributeKeys.InterlaceMode, (int) VideoInterlaceMode.Progressive);
@@ -92,6 +102,7 @@ namespace DesktopDuplication
 
         public void Dispose()
         {
+            _writer.Finalize();
             _writer.Dispose();
         }
     }

--- a/src/DesktopDuplication/MfWriter.cs
+++ b/src/DesktopDuplication/MfWriter.cs
@@ -34,7 +34,7 @@ namespace DesktopDuplication
             return res;
         }
 
-        public MfWriter(Device Device, int Fps, int Width, int Height)
+        public MfWriter(Device Device, int Fps, int Width, int Height, string FileName)
         {
             var attr = new MediaAttributes(3);
             attr.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
@@ -44,7 +44,7 @@ namespace DesktopDuplication
             devMan.ResetDevice(Device);
             attr.Set(SinkWriterAttributeKeys.D3DManager, devMan);
 
-            _writer = MediaFactory.CreateSinkWriterFromURL(@"output.mp4", null, attr);
+            _writer = MediaFactory.CreateSinkWriterFromURL(FileName, null, attr);
 
             using (var mediaTypeOut = new MediaType())
             {

--- a/src/DesktopDuplication/MfWriter.cs
+++ b/src/DesktopDuplication/MfWriter.cs
@@ -8,7 +8,7 @@ namespace DesktopDuplication
 {
     public class MfWriter : IDisposable
     {
-        const int BitRate = 4_000_000;
+        const int BitRate = 1_000_000;
         readonly Guid _encodingFormat = VideoFormatGuids.H264;
         readonly Guid _inputFormat = VideoFormatGuids.Rgb32;
 

--- a/src/DesktopDuplication/TextureAllocator.cs
+++ b/src/DesktopDuplication/TextureAllocator.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Concurrent;
+using SharpDX.Direct3D11;
+using SharpDX.MediaFoundation;
+
+namespace DesktopDuplication
+{
+    public class TextureAllocator : AsyncCallbackBase, IDisposable
+    {
+        ConcurrentStack<Texture2D> _mFreeStack;
+        static readonly Guid D3D11Texture2D = new Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
+
+        readonly Texture2DDescription _textureDescription;
+        readonly Device _device;
+
+        // If all textures are the exact same size and color format,
+        // consider making those parameters private class members and
+        // requiring they be specified as arguments to the constructor.
+        public TextureAllocator(Texture2DDescription TextureDescription, Device Device)
+        {
+            _textureDescription = TextureDescription;
+            _device = Device;
+            _mFreeStack = new ConcurrentStack<Texture2D>();
+        }
+
+        bool _disposedValue;
+
+        protected override void Dispose(bool Disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (Disposing)
+                {
+                    // Dispose managed resources here
+                }
+
+                if (_mFreeStack != null)
+                {
+                    while (_mFreeStack.TryPop(out var texture))
+                    {
+                        texture.Dispose();
+                    }
+
+                    _mFreeStack = null;
+                }
+
+                _disposedValue = true;
+            }
+
+            base.Dispose(Disposing);
+        }
+
+        public new void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~TextureAllocator()
+        {
+            Dispose(false);
+        }
+
+        Texture2D InternalAllocateNewTexture()
+        {
+            return new Texture2D(_device, _textureDescription);
+        }
+
+        public Texture2D AllocateTexture()
+        {
+            if (_mFreeStack.TryPop(out var existingTexture))
+            {
+                return existingTexture;
+            }
+
+            return InternalAllocateNewTexture();
+        }
+
+        public Sample CreateSample(Texture2D Texture)
+        {
+            // Create the video sample. This function returns an IMFTrackedSample per MSDN
+            var sample = MediaFactory.CreateVideoSampleFromSurface(null);
+            
+            // Query the IMFSample to see if it implements IMFTrackedSample
+            var trackedSample = sample.QueryInterface<TrackedSample>();
+            
+            // Create the media buffer from the texture
+            MediaFactory.CreateDXGISurfaceBuffer(D3D11Texture2D, Texture, 0, false, out var mediaBuffer);
+
+            // Set the owning instance of this class as the allocator
+            // for IMFTrackedSample to notify when the sample is released
+            trackedSample.SetAllocator(this, null);
+
+            // Attach the created buffer to the sample
+            sample.AddBuffer(mediaBuffer);
+
+            return sample;
+        }
+
+        // This is public so any textures you allocate but don't make IMFSamples 
+        // out of can be returned to the allocator manually.
+        void ReturnFreeTexture(Texture2D FreeTexture)
+        {
+            _mFreeStack.Push(FreeTexture);
+        }
+
+        public override void Invoke(AsyncResult Result)
+        {
+            var sample = Result.QueryInterface<Sample>();
+
+            // Based on your implementation, there should only be one 
+            // buffer attached to one sample, so we can always grab the
+            // first buffer. You could add some error checking here to make
+            // sure the sample has a buffer count that is 1.
+            var mediaBuffer = sample.GetBufferByIndex(0);
+
+            var dxgiBuffer = mediaBuffer.QueryInterface<DXGIBuffer>();
+            
+            // Got an IMFDXGIBuffer, so we can extract the internal 
+            // ID3D11Texture2D and make a new SharpDX.Texture2D wrapper.
+            dxgiBuffer.GetResource(D3D11Texture2D, out var texturePtr);
+
+            ReturnFreeTexture(new Texture2D(texturePtr));
+        }
+    }
+}

--- a/src/DesktopDuplication/TextureAllocator.cs
+++ b/src/DesktopDuplication/TextureAllocator.cs
@@ -91,6 +91,8 @@ namespace DesktopDuplication
             // for IMFTrackedSample to notify when the sample is released
             trackedSample.SetAllocator(this, null);
 
+            mediaBuffer.CurrentLength = mediaBuffer.QueryInterface<Buffer2D>().ContiguousLength;
+
             // Attach the created buffer to the sample
             sample.AddBuffer(mediaBuffer);
 

--- a/src/DesktopDuplication/TextureAllocator.cs
+++ b/src/DesktopDuplication/TextureAllocator.cs
@@ -13,7 +13,7 @@ namespace DesktopDuplication
         readonly Texture2DDescription _textureDescription;
         readonly Device _device;
 
-        const int TextureCount = 120;
+        const int TextureCount = 15;
         readonly Texture2D[] _textures = new Texture2D[TextureCount];
         int _currentTexture = -1;
 

--- a/src/DesktopDuplication/TextureAllocator.cs
+++ b/src/DesktopDuplication/TextureAllocator.cs
@@ -7,11 +7,15 @@ namespace DesktopDuplication
 {
     public class TextureAllocator : AsyncCallbackBase, IDisposable
     {
-        ConcurrentStack<Texture2D> _mFreeStack;
+        //ConcurrentStack<Texture2D> _mFreeStack;
         static readonly Guid D3D11Texture2D = new Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
 
         readonly Texture2DDescription _textureDescription;
         readonly Device _device;
+
+        const int TextureCount = 30;
+        readonly Texture2D[] _textures = new Texture2D[TextureCount];
+        int _currentTexture = -1;
 
         // If all textures are the exact same size and color format,
         // consider making those parameters private class members and
@@ -20,7 +24,7 @@ namespace DesktopDuplication
         {
             _textureDescription = TextureDescription;
             _device = Device;
-            _mFreeStack = new ConcurrentStack<Texture2D>();
+            //_mFreeStack = new ConcurrentStack<Texture2D>();
         }
 
         bool _disposedValue;
@@ -34,14 +38,19 @@ namespace DesktopDuplication
                     // Dispose managed resources here
                 }
 
-                if (_mFreeStack != null)
-                {
-                    while (_mFreeStack.TryPop(out var texture))
-                    {
-                        texture.Dispose();
-                    }
+                //if (_mFreeStack != null)
+                //{
+                //    while (_mFreeStack.TryPop(out var texture))
+                //    {
+                //        texture.Dispose();
+                //    }
 
-                    _mFreeStack = null;
+                //    _mFreeStack = null;
+                //}
+
+                foreach (var texture in _textures)
+                {
+                    texture?.Dispose();
                 }
 
                 _disposedValue = true;
@@ -68,12 +77,14 @@ namespace DesktopDuplication
 
         public Texture2D AllocateTexture()
         {
-            if (_mFreeStack.TryPop(out var existingTexture))
-            {
-                return existingTexture;
-            }
+            //if (_mFreeStack.TryPop(out var existingTexture))
+            //{
+            //    return existingTexture;
+            //}
 
-            return InternalAllocateNewTexture();
+            _currentTexture = ++_currentTexture % TextureCount;
+
+            return _textures[_currentTexture] ?? (_textures[_currentTexture] = InternalAllocateNewTexture());
         }
 
         public Sample CreateSample(Texture2D Texture)
@@ -103,7 +114,7 @@ namespace DesktopDuplication
         // out of can be returned to the allocator manually.
         void ReturnFreeTexture(Texture2D FreeTexture)
         {
-            _mFreeStack.Push(FreeTexture);
+            //_mFreeStack.Push(FreeTexture);
         }
 
         public override void Invoke(AsyncResult Result)

--- a/src/DesktopDuplication/TextureAllocator.cs
+++ b/src/DesktopDuplication/TextureAllocator.cs
@@ -13,7 +13,7 @@ namespace DesktopDuplication
         readonly Texture2DDescription _textureDescription;
         readonly Device _device;
 
-        const int TextureCount = 30;
+        const int TextureCount = 120;
         readonly Texture2D[] _textures = new Texture2D[TextureCount];
         int _currentTexture = -1;
 
@@ -93,14 +93,14 @@ namespace DesktopDuplication
             var sample = MediaFactory.CreateVideoSampleFromSurface(null);
             
             // Query the IMFSample to see if it implements IMFTrackedSample
-            var trackedSample = sample.QueryInterface<TrackedSample>();
+            //var trackedSample = sample.QueryInterface<TrackedSample>();
             
             // Create the media buffer from the texture
             MediaFactory.CreateDXGISurfaceBuffer(D3D11Texture2D, Texture, 0, false, out var mediaBuffer);
 
             // Set the owning instance of this class as the allocator
             // for IMFTrackedSample to notify when the sample is released
-            trackedSample.SetAllocator(this, null);
+            //trackedSample.SetAllocator(this, null);
 
             mediaBuffer.CurrentLength = mediaBuffer.QueryInterface<Buffer2D>().ContiguousLength;
 

--- a/src/DesktopDuplication/app.config
+++ b/src/DesktopDuplication/app.config
@@ -1,11 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-  </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <probing privatePath="lib" />
       <dependentAssembly>
         <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />

--- a/src/DesktopDuplication/packages.config
+++ b/src/DesktopDuplication/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpDX" version="4.1.0" targetFramework="net461" />
+  <package id="SharpDX" version="4.2.0-ci259" targetFramework="net461" />
   <package id="SharpDX.Direct3D11" version="4.1.0" targetFramework="net461" />
-  <package id="SharpDX.Direct3D9" version="4.1.0" targetFramework="net461" />
-  <package id="SharpDX.DXGI" version="4.1.0" targetFramework="net461" />
-  <package id="SharpDX.Mathematics" version="4.1.0" targetFramework="net461" />
-  <package id="SharpDX.MediaFoundation" version="4.1.0" targetFramework="net461" />
+  <package id="SharpDX.Direct3D9" version="4.2.0-ci259" targetFramework="net461" />
+  <package id="SharpDX.DXGI" version="4.2.0-ci259" targetFramework="net461" />
+  <package id="SharpDX.Mathematics" version="4.2.0-ci259" targetFramework="net461" />
+  <package id="SharpDX.MediaFoundation" version="4.2.0-ci259" targetFramework="net461" />
 </packages>

--- a/src/DesktopDuplication/packages.config
+++ b/src/DesktopDuplication/packages.config
@@ -2,5 +2,8 @@
 <packages>
   <package id="SharpDX" version="4.1.0" targetFramework="net461" />
   <package id="SharpDX.Direct3D11" version="4.1.0" targetFramework="net461" />
+  <package id="SharpDX.Direct3D9" version="4.1.0" targetFramework="net461" />
   <package id="SharpDX.DXGI" version="4.1.0" targetFramework="net461" />
+  <package id="SharpDX.Mathematics" version="4.1.0" targetFramework="net461" />
+  <package id="SharpDX.MediaFoundation" version="4.1.0" targetFramework="net461" />
 </packages>

--- a/src/Tests/app.config
+++ b/src/Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
@@ -17,6 +17,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SharpDX.DXGI" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
`WORK IN PROGRESS`

The idea is to send `Desktop Duplication` textures directly to a hardware encoder.
GPU is much faster compared to CPU, so if copying the texture from GPU to CPU can be avoided, and instead directly sent to the encoder, there would a considerable increase in performance.

As of now, this branch is not in a good state.
Most of it is messed up.