### PR TITLE
Thin Region Selector

### DIFF
--- a/src/Captura.Core/Settings/Models/VisualSettings.cs
+++ b/src/Captura.Core/Settings/Models/VisualSettings.cs
@@ -68,12 +68,6 @@
             set => Set(value);
         }
 
-        public bool HideRegionSelectorWhenRecording
-        {
-            get => Get(false);
-            set => Set(value);
-        }
-
         public string Language
         {
             get => Get("en");

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Pages\ScreenShotsPage.xaml.cs">
       <DependentUpon>ScreenShotsPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ValueConverters\IsLessThanConverter.cs" />
     <Compile Include="ValueConverters\StaticResourceConverter.cs" />
     <Compile Include="Windows\RegionPickerWindow.xaml.cs">
       <DependentUpon>RegionPickerWindow.xaml</DependentUpon>

--- a/src/Captura/ValueConverters/IsLessThanConverter.cs
+++ b/src/Captura/ValueConverters/IsLessThanConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Captura
+{
+    public class IsLessThanConverter : OneWayConverter
+    {
+        public override object Convert(object Value, Type TargetType, object Parameter, CultureInfo Culture)
+        {
+            if (double.TryParse(Value?.ToString(), out var left) && double.TryParse(Parameter?.ToString(), out var right))
+            {
+                return left < right;
+            }
+
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/src/Captura/ValueConverters/ValueConverters.xaml
+++ b/src/Captura/ValueConverters/ValueConverters.xaml
@@ -14,5 +14,6 @@
     <captura:IntegralTimeSpanConverter x:Key="IntegralTimeSpanConverter"/>
     <captura:GetTypeConverter x:Key="GetTypeConverter"/>
     <captura:StaticResourceConverter x:Key="StaticResourceConverter"/>
+    <captura:IsLessThanConverter x:Key="IsLessThanConverter"/>
     <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
 </ResourceDictionary>

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -16,6 +16,17 @@
         SizeToContent="WidthAndHeight"
         Name="This">
     <Grid>
+        <Grid.Resources>
+            <Style x:Key="BlurWithoutHover" TargetType="FrameworkElement">
+                <Setter Property="Opacity" Value="0.2"/>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Opacity" Value="1"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </Grid.Resources>
+
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
@@ -175,7 +186,8 @@
                 Grid.RowSpan="2"
                 BorderBrush="{DynamicResource Accent}"
                 BorderThickness="1"
-                VerticalAlignment="Top">
+                VerticalAlignment="Top"
+                Style="{StaticResource BlurWithoutHover}">
             <DockPanel Background="{DynamicResource WindowBackground}"
                        LastChildFill="False">
                 <ListBox Name="ModesBox"

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -8,15 +8,13 @@
         xmlns:viewModels="clr-namespace:Captura.ViewModels;assembly=Captura.Core"
         mc:Ignorable="d"
         Title="{Binding RegionSelector, Source={StaticResource Loc}, Mode=OneWay}"
-        Height="500"
         Background="Transparent"
-        Width="400"
         WindowStyle="None"
         AllowsTransparency="True"
         Topmost="True"
-        ResizeMode="CanResize"
-        MinHeight="50"
-        MinWidth="50">
+        ResizeMode="NoResize"
+        SizeToContent="WidthAndHeight"
+        Name="This">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition/>
@@ -27,7 +25,12 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
-        <Border BorderThickness="2">
+        <Border BorderThickness="2"
+                Name="Region"
+                Height="500"
+                Width="400"
+                MinHeight="50"
+                MinWidth="50">
             <Border.BorderBrush>
                 <DrawingBrush TileMode="Tile" Viewport="0,0,0.05,0.05">
                     <DrawingBrush.Drawing>
@@ -62,8 +65,7 @@
               Grid.Column="0"
               Margin="0,10,0,0">
             <Border BorderThickness="1"
-                    BorderBrush="{DynamicResource Accent}"
-                    HorizontalAlignment="Right">
+                    BorderBrush="{DynamicResource Accent}">
                 <DockPanel HorizontalAlignment="Right"
                            Background="{DynamicResource WindowBackground}">
                     <xctk:IntegerUpDown Width="60"
@@ -80,11 +82,24 @@
                                         Margin="3"
                                         Name="WidthBox"/>
                 </DockPanel>
+
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="HorizontalAlignment" Value="Right"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Width, ElementName=This, Converter={StaticResource IsLessThanConverter}, ConverterParameter=500}" Value="True">
+                                <Setter Property="HorizontalAlignment" Value="Left"/>
+                                <Setter Property="Margin" Value="0,40,0,0"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
             </Border>
 
             <Border BorderThickness="1"
                     BorderBrush="{DynamicResource Accent}"
-                    HorizontalAlignment="Left">
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top">
                 <DockPanel Name="MainControls"
                            Background="{DynamicResource WindowBackground}"
                            d:DataContext="{d:DesignInstance viewModels:MainViewModel}">

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -14,90 +14,95 @@
         WindowStyle="None"
         AllowsTransparency="True"
         Topmost="True"
-        BorderBrush="{DynamicResource Accent}"
-        BorderThickness="1"
         ResizeMode="CanResize"
-        MinHeight="250"
-        MinWidth="250">
-    <WindowChrome.WindowChrome>
-        <WindowChrome CornerRadius="0"
-                      CaptionHeight="30"
-                      ResizeBorderThickness="3"
-                      NonClientFrameEdges="None"/>
-    </WindowChrome.WindowChrome>
-    <Border BorderThickness="5"
-            BorderBrush="{DynamicResource WindowBackground}">
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="30"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="30"/>
-            </Grid.RowDefinitions>
-            
-            <DockPanel Background="{DynamicResource WindowBackground}"
-                       Grid.Row="1"
-                       LastChildFill="False"
-                       Margin="-5,0,0,0">
-                <ListBox Name="ModesBox"
-                         SelectedValuePath="Key"
-                         DockPanel.Dock="Top"
-                         HorizontalAlignment="Center"
-                         SelectionChanged="ModesBox_OnSelectionChanged">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <Path Data="{Binding Key, Converter={StaticResource InkToolToIconConverter}}"
-                                  Width="15"
-                                  Height="15"
-                                  Stretch="Uniform"
-                                  HorizontalAlignment="Center"
-                                  VerticalAlignment="Center"
-                                  ToolTip="{Binding Value}"
-                                  Fill="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=ContentControl}}"
-                                  ToolTipService.Placement="Left"
-                                  Margin="5"/>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
+        MinHeight="50"
+        MinWidth="50">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
 
-                <xctk:ColorPicker Margin="0,2"
-                                  BorderThickness="2"
-                                  Width="35"
-                                  DockPanel.Dock="Bottom"
-                                  Name="ColorPicker"
-                                  SelectedColorChanged="ColorPicker_OnSelectedColorChanged"
-                                  VerticalContentAlignment="Stretch"
-                                  ColorMode="ColorCanvas"
-                                  ShowAdvancedButton="True"
-                                  AdvancedButtonHeader="Color Canvas"
-                                  StandardButtonHeader="Pallette"
-                                  ShowRecentColors="True"/>
+        <Border BorderThickness="2">
+            <Border.BorderBrush>
+                <DrawingBrush TileMode="Tile" Viewport="0,0,0.05,0.05">
+                    <DrawingBrush.Drawing>
+                        <DrawingGroup>
+                            <GeometryDrawing Brush="{DynamicResource WindowBackground}">
+                                <GeometryDrawing.Geometry>
+                                    <GeometryGroup>
+                                        <RectangleGeometry Rect="0,0,10,10" />
+                                        <RectangleGeometry Rect="10,10,10,10" />
+                                    </GeometryGroup>
+                                </GeometryDrawing.Geometry>
+                            </GeometryDrawing>
 
-                <xctk:IntegerUpDown Name="SizeBox"
-                                    Minimum="1"
-                                    Maximum="99"
-                                    DockPanel.Dock="Bottom"
-                                    ValueChanged="SizeBox_OnValueChanged"
-                                    Margin="0,2"
-                                    Width="40"/>
-            </DockPanel>
+                            <GeometryDrawing Brush="{DynamicResource Accent}">
+                                <GeometryDrawing.Geometry>
+                                    <GeometryGroup>
+                                        <RectangleGeometry Rect="10,0,10,10" />
+                                        <RectangleGeometry Rect="0,10,10,10" />
+                                    </GeometryGroup>
+                                </GeometryDrawing.Geometry>
+                            </GeometryDrawing>
+                        </DrawingGroup>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Border.BorderBrush>
 
-            <Label Background="{DynamicResource WindowBackground}"
-                   HorizontalContentAlignment="Stretch"
-                   Margin="-1,-5,0,0"
-                   Grid.ColumnSpan="2">
+            <InkCanvas Background="Transparent"
+                       Name="InkCanvas"/>
+        </Border>
+
+        <Grid Grid.Row="1"
+              Grid.Column="0"
+              Margin="0,10,0,0">
+            <Border BorderThickness="1"
+                    BorderBrush="{DynamicResource Accent}"
+                    HorizontalAlignment="Right">
+                <DockPanel HorizontalAlignment="Right"
+                           Background="{DynamicResource WindowBackground}">
+                    <xctk:IntegerUpDown Width="60"
+                                        DockPanel.Dock="Right"
+                                        Margin="3"
+                                        Name="HeightBox"/>
+
+                    <Label Content="x"
+                           DockPanel.Dock="Right"
+                           Margin="7,3"/>
+
+                    <xctk:IntegerUpDown Width="60"
+                                        DockPanel.Dock="Right"
+                                        Margin="3"
+                                        Name="WidthBox"/>
+                </DockPanel>
+            </Border>
+
+            <Border BorderThickness="1"
+                    BorderBrush="{DynamicResource Accent}"
+                    HorizontalAlignment="Left">
                 <DockPanel Name="MainControls"
+                           Background="{DynamicResource WindowBackground}"
                            d:DataContext="{d:DesignInstance viewModels:MainViewModel}">
+                    <DockPanel.Resources>
+                        <Style TargetType="local:ModernButton" BasedOn="{StaticResource {x:Type local:ModernButton}}">
+                            <Setter Property="LayoutTransform">
+                                <Setter.Value>
+                                    <ScaleTransform ScaleX="0.85" ScaleY="0.85"/>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </DockPanel.Resources>
+
                     <local:ModernButton IconData="{StaticResource IconSnapToWindow}"
-                                        Background="{DynamicResource WindowBackground}"
                                         x:Name="Snapper"
                                         Click="Snapper_OnClick"
                                         WindowChrome.IsHitTestVisibleInChrome="True"
-                                        ToolTip="Snap to Window"
-                                        ToolTipService.Placement="Top"/>
+                                        ToolTip="Snap to Window"/>
 
                     <local:ModernButton x:Name="CloseButton"
                                         Click="CloseButton_Click"
@@ -106,30 +111,26 @@
                                         IconData="{StaticResource IconClose}"
                                         DockPanel.Dock="Right"
                                         WindowChrome.IsHitTestVisibleInChrome="True"
-                                        ToolTip="{Binding Close, Source={StaticResource Loc}, Mode=OneWay}"
-                                        ToolTipService.Placement="Top"/>
+                                        ToolTip="{Binding Close, Source={StaticResource Loc}, Mode=OneWay}"/>
 
                     <local:ModernButton Command="{Binding ScreenShotViewModel.ScreenShotCommand}"
                                         IconData="{StaticResource IconCamera}"
                                         DockPanel.Dock="Right"
                                         Opacity="0.9"
                                         WindowChrome.IsHitTestVisibleInChrome="True"
-                                        ToolTip="{Binding ScreenShot, Source={StaticResource Loc}, Mode=OneWay}"
-                                        ToolTipService.Placement="Top"/>
-                    
+                                        ToolTip="{Binding ScreenShot, Source={StaticResource Loc}, Mode=OneWay}"/>
+
                     <local:ModernButton Command="{Binding RecordingViewModel.RecordCommand}"
                                         Foreground="#b71c1c"
                                         IconData="{Binding RecordingViewModel.RecorderState, Converter={StaticResource StateToRecordButtonGeometryConverter}}"
                                         WindowChrome.IsHitTestVisibleInChrome="True"
-                                        ToolTip="{Binding RecordStop, Source={StaticResource Loc}, Mode=OneWay}"
-                                        ToolTipService.Placement="Top"/>
-                    
+                                        ToolTip="{Binding RecordStop, Source={StaticResource Loc}, Mode=OneWay}"/>
+
                     <local:ModernButton Command="{Binding RecordingViewModel.PauseCommand}"
                                         IconData="{StaticResource IconPause}"
                                         Opacity="0.9"
                                         WindowChrome.IsHitTestVisibleInChrome="True"
-                                        ToolTip="{Binding PauseResume, Source={StaticResource Loc}, Mode=OneWay}"
-                                        ToolTipService.Placement="Top">
+                                        ToolTip="{Binding PauseResume, Source={StaticResource Loc}, Mode=OneWay}">
                         <local:ModernButton.Style>
                             <Style TargetType="local:ModernButton" BasedOn="{StaticResource {x:Type local:ModernButton}}">
                                 <Style.Triggers>
@@ -146,45 +147,72 @@
                     </local:ModernButton>
 
                     <Label Content="{Binding RecordingViewModel.TimeSpan}"
-                           Margin="0,-1"
-                           HorizontalContentAlignment="Center"/>
+                           Margin="10,-1"
+                           HorizontalContentAlignment="Center"
+                           PreviewMouseLeftButtonDown="UIElement_OnPreviewMouseLeftButtonDown"/>
                 </DockPanel>
-            </Label>
-
-            <Border BorderThickness="1"
-                    BorderBrush="{DynamicResource Accent}"
-                    Grid.Row="1"
-                    Grid.Column="1">
-                <InkCanvas Background="Transparent"
-                           Name="InkCanvas"/>
             </Border>
-
-            <DockPanel Grid.Row="2"
-                       Margin="-1,0,-1,-1"
-                       Background="{DynamicResource WindowBackground}"
-                       Grid.ColumnSpan="2">
-                <xctk:IntegerUpDown Width="60"
-                                    DockPanel.Dock="Right"
-                                    Margin="0,5,0,0"
-                                    Name="HeightBox"/>
-                
-                <Label Content="x"
-                       DockPanel.Dock="Right"
-                       Margin="10,0"/>
-
-                <xctk:IntegerUpDown Width="60"
-                                    DockPanel.Dock="Right"
-                                    Margin="0,5,0,0"
-                                    Name="WidthBox"/>
-
-                <CheckBox DataContext="{Binding AboutViewModel, Source={StaticResource ServiceLocator}}"
-                          IsChecked="{Binding Settings.UI.HideRegionSelectorWhenRecording}"
-                          Margin="0,2">
-                    <TextBlock TextWrapping="Wrap"
-                               FontSize="11"
-                               Text="Hide when Recording"/>
-                </CheckBox>
-            </DockPanel>
         </Grid>
-    </Border>
+
+        <Border Grid.Row="0"
+                Margin="10,0,0,0"
+                Grid.Column="1"
+                Grid.RowSpan="2"
+                BorderBrush="{DynamicResource Accent}"
+                BorderThickness="1"
+                VerticalAlignment="Top">
+            <DockPanel Background="{DynamicResource WindowBackground}"
+                       LastChildFill="False">
+                <ListBox Name="ModesBox"
+                         SelectedValuePath="Key"
+                         DockPanel.Dock="Top"
+                         Margin="0,0,0,10"
+                         HorizontalContentAlignment="Center"
+                         SelectionChanged="ModesBox_OnSelectionChanged">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <Path Data="{Binding Key, Converter={StaticResource InkToolToIconConverter}}"
+                                  Width="12"
+                                  Height="12"
+                                  Stretch="Uniform"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  ToolTip="{Binding Value}"
+                                  Fill="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=ContentControl}}"
+                                  Margin="5"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <xctk:ColorPicker Margin="0,2"
+                                  BorderThickness="2"
+                                  Width="35"
+                                  DockPanel.Dock="Bottom"
+                                  Name="ColorPicker"
+                                  SelectedColorChanged="ColorPicker_OnSelectedColorChanged"
+                                  VerticalContentAlignment="Stretch"
+                                  ColorMode="ColorCanvas"
+                                  ShowAdvancedButton="True"
+                                  AdvancedButtonHeader="Color Canvas"
+                                  StandardButtonHeader="Pallette"
+                                  ShowRecentColors="True">
+                    <xctk:ColorPicker.LayoutTransform>
+                        <ScaleTransform ScaleX="0.85" ScaleY="0.85"/>
+                    </xctk:ColorPicker.LayoutTransform>
+                </xctk:ColorPicker>
+
+                <xctk:IntegerUpDown Name="SizeBox"
+                                    Minimum="1"
+                                    Maximum="99"
+                                    DockPanel.Dock="Bottom"
+                                    ValueChanged="SizeBox_OnValueChanged"
+                                    Margin="0,2"
+                                    Width="40">
+                    <xctk:IntegerUpDown.LayoutTransform>
+                        <ScaleTransform ScaleX="0.85" ScaleY="0.85"/>
+                    </xctk:IntegerUpDown.LayoutTransform>
+                </xctk:IntegerUpDown>
+            </DockPanel>
+        </Border>
+    </Grid>
 </Window>

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -16,6 +16,16 @@
         SizeToContent="WidthAndHeight"
         Name="This">
     <Grid>
+        <Grid.Resources>
+            <Style TargetType="Thumb">
+                <Setter Property="Opacity" Value="0.01"/>
+                <EventSetter Event="DragDelta" Handler="Thumb_OnDragDelta"/>
+            </Style>
+            <Style x:Key="CornerThumb" TargetType="Thumb" BasedOn="{StaticResource {x:Type Thumb}}">
+                <Setter Property="Height" Value="5"/>
+                <Setter Property="Width" Value="5"/>
+            </Style>
+        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
@@ -29,8 +39,8 @@
                 Name="Region"
                 Height="500"
                 Width="400"
-                MinHeight="50"
-                MinWidth="50">
+                MinHeight="200"
+                MinWidth="300">
             <Border.BorderBrush>
                 <DrawingBrush TileMode="Tile" Viewport="0,0,0.05,0.05">
                     <DrawingBrush.Drawing>
@@ -63,31 +73,47 @@
 
         <Thumb VerticalAlignment="Top"
                Height="2"
-               Opacity="0.01"
                Cursor="SizeNS"
-               Tag="Top"
-               DragDelta="Thumb_OnDragDelta"/>
+               Tag="Top"/>
 
         <Thumb VerticalAlignment="Bottom"
                Height="2"
-               Opacity="0.01"
                Cursor="SizeNS"
-               Tag="Bottom"
-               DragDelta="Thumb_OnDragDelta"/>
+               Tag="Bottom"/>
 
         <Thumb HorizontalAlignment="Left"
                Width="2"
-               Opacity="0.01"
                Cursor="SizeWE"
-               Tag="Left"
-               DragDelta="Thumb_OnDragDelta"/>
+               Tag="Left"/>
         
         <Thumb HorizontalAlignment="Right"
                Width="2"
-               Opacity="0.01"
                Cursor="SizeWE"
-               Tag="Right"
-               DragDelta="Thumb_OnDragDelta"/>
+               Tag="Right"/>
+
+        <Thumb HorizontalAlignment="Left"
+               VerticalAlignment="Top"
+               Style="{StaticResource CornerThumb}"
+               Cursor="SizeNWSE"
+               Tag="TopLeft"/>
+
+        <Thumb HorizontalAlignment="Right"
+               VerticalAlignment="Top"
+               Style="{StaticResource CornerThumb}"
+               Cursor="SizeNESW"
+               Tag="TopRight"/>
+
+        <Thumb HorizontalAlignment="Left"
+               VerticalAlignment="Bottom"
+               Style="{StaticResource CornerThumb}"
+               Cursor="SizeNESW"
+               Tag="BottomLeft"/>
+
+        <Thumb HorizontalAlignment="Right"
+               VerticalAlignment="Bottom"
+               Style="{StaticResource CornerThumb}"
+               Cursor="SizeNWSE"
+               Tag="BottomRight"/>
 
         <Grid Grid.Row="1"
               Grid.Column="0"

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -151,8 +151,24 @@
                                     <Condition Binding="{Binding IsMouseOver, ElementName=SizeBorder}" Value="False"/>
                                     <Condition Binding="{Binding DataContext.RecordingViewModel.RecorderState, ElementName=RecordBtn, Converter={StaticResource NotRecordingConverter}}" Value="False"/>
                                 </MultiDataTrigger.Conditions>
-
-                                <Setter Property="Opacity" Value="0.1"/>
+                                <MultiDataTrigger.EnterActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                             To="0.2"
+                                                             Duration="0:0:0.3" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </MultiDataTrigger.EnterActions>
+                                <MultiDataTrigger.ExitActions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                             To="1"
+                                                             Duration="0:0:0.3" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </MultiDataTrigger.ExitActions>
                             </MultiDataTrigger>
                         </Style.Triggers>
                     </Style>
@@ -298,7 +314,24 @@
                     <Setter Property="Opacity" Value="0.2"/>
                     <Style.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Opacity" Value="1"/>
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                         To="1"
+                                                         Duration="0:0:0.3" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                         To="0.2"
+                                                         Duration="0:0:0.3" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.ExitActions>
                         </Trigger>
                     </Style.Triggers>
                 </Style>

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -16,17 +16,6 @@
         SizeToContent="WidthAndHeight"
         Name="This">
     <Grid>
-        <Grid.Resources>
-            <Style x:Key="BlurWithoutHover" TargetType="FrameworkElement">
-                <Setter Property="Opacity" Value="0.2"/>
-                <Style.Triggers>
-                    <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Opacity" Value="1"/>
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
-        </Grid.Resources>
-
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
@@ -76,6 +65,7 @@
               Grid.Column="0"
               Margin="0,10,0,0">
             <Border BorderThickness="1"
+                    Name="SizeBorder"
                     BorderBrush="{DynamicResource Accent}">
                 <DockPanel HorizontalAlignment="Right"
                            Background="{DynamicResource WindowBackground}">
@@ -102,6 +92,14 @@
                                 <Setter Property="HorizontalAlignment" Value="Left"/>
                                 <Setter Property="Margin" Value="0,40,0,0"/>
                             </DataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding IsMouseOver, ElementName=SizeBorder}" Value="False"/>
+                                    <Condition Binding="{Binding DataContext.RecordingViewModel.RecorderState, ElementName=RecordBtn, Converter={StaticResource NotRecordingConverter}}" Value="False"/>
+                                </MultiDataTrigger.Conditions>
+
+                                <Setter Property="Opacity" Value="0.1"/>
+                            </MultiDataTrigger>
                         </Style.Triggers>
                     </Style>
                 </Border.Style>
@@ -148,6 +146,7 @@
 
                     <local:ModernButton Command="{Binding RecordingViewModel.RecordCommand}"
                                         Foreground="#b71c1c"
+                                        x:Name="RecordBtn"
                                         IconData="{Binding RecordingViewModel.RecorderState, Converter={StaticResource StateToRecordButtonGeometryConverter}}"
                                         WindowChrome.IsHitTestVisibleInChrome="True"
                                         ToolTip="{Binding RecordStop, Source={StaticResource Loc}, Mode=OneWay}"/>
@@ -186,8 +185,7 @@
                 Grid.RowSpan="2"
                 BorderBrush="{DynamicResource Accent}"
                 BorderThickness="1"
-                VerticalAlignment="Top"
-                Style="{StaticResource BlurWithoutHover}">
+                VerticalAlignment="Top">
             <DockPanel Background="{DynamicResource WindowBackground}"
                        LastChildFill="False">
                 <ListBox Name="ModesBox"
@@ -240,6 +238,17 @@
                     </xctk:IntegerUpDown.LayoutTransform>
                 </xctk:IntegerUpDown>
             </DockPanel>
+
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Opacity" Value="0.2"/>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Opacity" Value="1"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
         </Border>
     </Grid>
 </Window>

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -61,6 +61,34 @@
                        Name="InkCanvas"/>
         </Border>
 
+        <Thumb VerticalAlignment="Top"
+               Height="2"
+               Opacity="0.01"
+               Cursor="SizeNS"
+               Tag="Top"
+               DragDelta="Thumb_OnDragDelta"/>
+
+        <Thumb VerticalAlignment="Bottom"
+               Height="2"
+               Opacity="0.01"
+               Cursor="SizeNS"
+               Tag="Bottom"
+               DragDelta="Thumb_OnDragDelta"/>
+
+        <Thumb HorizontalAlignment="Left"
+               Width="2"
+               Opacity="0.01"
+               Cursor="SizeWE"
+               Tag="Left"
+               DragDelta="Thumb_OnDragDelta"/>
+        
+        <Thumb HorizontalAlignment="Right"
+               Width="2"
+               Opacity="0.01"
+               Cursor="SizeWE"
+               Tag="Right"
+               DragDelta="Thumb_OnDragDelta"/>
+
         <Grid Grid.Row="1"
               Grid.Column="0"
               Margin="0,10,0,0">

--- a/src/Captura/Windows/RegionSelector.xaml.cs
+++ b/src/Captura/Windows/RegionSelector.xaml.cs
@@ -291,5 +291,10 @@ namespace Captura
                 finally { Top = 0; }
             }
         }
+
+        void UIElement_OnPreviewMouseLeftButtonDown(object Sender, MouseButtonEventArgs E)
+        {
+            DragMove();
+        }
     }
 }

--- a/src/Captura/Windows/RegionSelector.xaml.cs
+++ b/src/Captura/Windows/RegionSelector.xaml.cs
@@ -81,17 +81,15 @@ namespace Captura
                 InkCanvas.DefaultDrawingAttributes.Color = E.NewValue.Value;
         }
 
-        const int LeftOffset = 43,
-            TopOffset = 38,
-            WidthBorder = LeftOffset + 7,
-            HeightBorder = TopOffset + 37;
+        const int LeftOffset = 2,
+            TopOffset = 2;
 
         Rectangle? _region;
         
         void InitDimensionBoxes()
         {
-            WidthBox.Minimum = (int)((MinWidth - WidthBorder) * Dpi.X);
-            HeightBox.Minimum = (int)((MinHeight - HeightBorder) * Dpi.Y);
+            WidthBox.Minimum = (int)((Region.MinWidth - LeftOffset * 2) * Dpi.X);
+            HeightBox.Minimum = (int)((Region.MinHeight - TopOffset * 2) * Dpi.Y);
 
             void SizeChange()
             {
@@ -196,8 +194,8 @@ namespace Captura
             _region = Dispatcher.Invoke(() =>
                 new Rectangle((int)((Left + LeftOffset) * Dpi.X),
                     (int)((Top + TopOffset) * Dpi.Y),
-                    (int)((Width - WidthBorder) * Dpi.X),
-                    (int)((Height - HeightBorder) * Dpi.Y)));
+                    (int)((Region.ActualWidth - 2 * LeftOffset) * Dpi.X),
+                    (int)((Region.ActualHeight - 2 * TopOffset) * Dpi.Y)));
 
             _regionItem.Name = _region.ToString().Replace("{", "")
                 .Replace("}", "")
@@ -221,8 +219,8 @@ namespace Captura
                 
                 Dispatcher.Invoke(() =>
                 {
-                    Width = value.Width / Dpi.X + WidthBorder;
-                    Height = value.Height / Dpi.Y + HeightBorder;
+                    Region.Width = value.Width / Dpi.X + 2 * LeftOffset;
+                    Region.Height = value.Height / Dpi.Y + 2 * TopOffset;
 
                     Left = value.Left / Dpi.X - LeftOffset;
                     Top = value.Top / Dpi.Y - TopOffset;
@@ -262,7 +260,6 @@ namespace Captura
         public IVideoItem VideoSource => _regionItem;
 
         public IntPtr Handle => new WindowInteropHelper(this).Handle;
-
         #endregion
 
         void Snapper_OnClick(object Sender, RoutedEventArgs E)

--- a/src/Captura/Windows/RegionSelector.xaml.cs
+++ b/src/Captura/Windows/RegionSelector.xaml.cs
@@ -236,11 +236,6 @@ namespace Captura
                 Snapper.IsEnabled = CloseButton.IsEnabled = false;
 
                 WidthBox.IsEnabled = HeightBox.IsEnabled = false;
-
-                if (ServiceProvider.Get<Settings>().UI.HideRegionSelectorWhenRecording)
-                {
-                    Hide();
-                }
             });
         }
         

--- a/src/Captura/Windows/RegionSelector.xaml.cs
+++ b/src/Captura/Windows/RegionSelector.xaml.cs
@@ -294,24 +294,98 @@ namespace Captura
         {
             if (Sender is FrameworkElement element)
             {
+                void DoTop()
+                {
+                    var oldTop = Top;
+                    var top = Top + E.VerticalChange;
+
+                    if (top > 0)
+                        Top = top;
+                    else
+                    {
+                        Top = 0;
+                        return;
+                    }
+
+                    var height = Region.Height - E.VerticalChange;
+
+                    if (height > Region.MinHeight)
+                        Region.Height = height;
+                    else Top = oldTop;
+                }
+
+                void DoLeft()
+                {
+                    var oldLeft = Left;
+                    var left = Left + E.HorizontalChange;
+
+                    if (left > 0)
+                        Left = left;
+                    else
+                    {
+                        Left = 0;
+                        return;
+                    }
+
+                    var width = Region.Width - E.HorizontalChange;
+
+                    if (width > Region.MinWidth)
+                        Region.Width = width;
+                    else Left = oldLeft;
+                }
+
+                void DoBottom()
+                {
+                    var height = Region.Height + E.VerticalChange;
+
+                    if (height > 0)
+                        Region.Height = height;
+                }
+
+                void DoRight()
+                {
+                    var width = Region.Width + E.HorizontalChange;
+
+                    if (width > 0)
+                        Region.Width = width;
+                }
+
                 switch (element.Tag)
                 {
                     case "Top":
-                        Top += E.VerticalChange;
-                        Region.Height -= E.VerticalChange;
+                        DoTop();
                         break;
 
                     case "Bottom":
-                        Region.Height += E.VerticalChange;
+                        DoBottom();
                         break;
 
                     case "Left":
-                        Left += E.HorizontalChange;
-                        Region.Width -= E.HorizontalChange;
+                        DoLeft();
                         break;
 
                     case "Right":
-                        Region.Width += E.HorizontalChange;
+                        DoRight();
+                        break;
+
+                    case "TopLeft":
+                        DoTop();
+                        DoLeft();
+                        break;
+
+                    case "TopRight":
+                        DoTop();
+                        DoRight();
+                        break;
+
+                    case "BottomLeft":
+                        DoBottom();
+                        DoLeft();
+                        break;
+
+                    case "BottomRight":
+                        DoBottom();
+                        DoRight();
                         break;
                 }
             }

--- a/src/Captura/Windows/RegionSelector.xaml.cs
+++ b/src/Captura/Windows/RegionSelector.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -287,6 +288,33 @@ namespace Captura
         void UIElement_OnPreviewMouseLeftButtonDown(object Sender, MouseButtonEventArgs E)
         {
             DragMove();
+        }
+
+        void Thumb_OnDragDelta(object Sender, DragDeltaEventArgs E)
+        {
+            if (Sender is FrameworkElement element)
+            {
+                switch (element.Tag)
+                {
+                    case "Top":
+                        Top += E.VerticalChange;
+                        Region.Height -= E.VerticalChange;
+                        break;
+
+                    case "Bottom":
+                        Region.Height += E.VerticalChange;
+                        break;
+
+                    case "Left":
+                        Left += E.HorizontalChange;
+                        Region.Width -= E.HorizontalChange;
+                        break;
+
+                    case "Right":
+                        Region.Width += E.HorizontalChange;
+                        break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Implementing a thinner Region Selector.
Lots of work to do!

#### To Do

- [x] Basic UI
- [x] fix captured Region
- [x] fix Snap to Window
- [x] Resizing using border
- [x] Lower opactiy of controls when not mouse over
- [x] move size boxes below main controls on small region size
- [x] remove `Hide during Recording` option.
- [x] low opacity of size boxes during recording.
- [x] low opacity animation.

#### First Look

![First Look](https://user-images.githubusercontent.com/10654537/45687031-3c28c600-bb6b-11e8-8798-e7fd2f1e70b4.png)
