### PR TITLE
Pre-Start Countdown

### DIFF
--- a/src/Captura.Core/Settings/Settings.cs
+++ b/src/Captura.Core/Settings/Settings.cs
@@ -103,7 +103,7 @@ namespace Captura
 
         public ObservableCollection<CustomImageOverlaySettings> ImageOverlays { get; } = new ObservableCollection<CustomImageOverlaySettings>();
 
-        public int StartDelay
+        public int PreStartCountdown
         {
             get => Get(0);
             set => Set(value);

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -197,18 +197,41 @@ namespace Captura.ViewModels
 
         public void InitTimer()
         {
-            _timer = new Timer(500);
+            _timer = new Timer(250);
             _timer.Elapsed += TimerOnElapsed;
         }
 
+        bool _waiting;
+
         async void TimerOnElapsed(object Sender, ElapsedEventArgs Args)
         {
+            if (Countdown > 0)
+            {
+                if (_timing.Elapsed.TotalSeconds > 1)
+                {
+                    _timing.Stop();
+
+                    --Countdown;
+
+                    _timing.Start();
+                }
+
+                return;
+            }
+
+            if (_waiting)
+            {
+                _waiting = false;
+
+                InternalStartRecording();
+            }
+
             TimeSpan = TimeSpan.FromSeconds((int)_timing.Elapsed.TotalSeconds);
 
             var duration = Settings.Duration;
 
             // If Capture Duration is set and reached
-            if (duration > 0 && TimeSpan.TotalSeconds >= Settings.StartDelay / 1000 + duration)
+            if (duration > 0 && TimeSpan.TotalSeconds >= duration)
             {
                 if (_syncContext != null)
                     _syncContext.Post(async State => await StopRecording(), null);
@@ -442,9 +465,7 @@ namespace Captura.ViewModels
 
             _timer?.Stop();
             TimeSpan = TimeSpan.Zero;
-
-            Status.LocalizationKey = Settings.StartDelay > 0 ? nameof(LanguageManager.Waiting) : nameof(LanguageManager.Recording);
-
+            
             _recorder.ErrorOccurred += E =>
             {
                 if (_syncContext != null)
@@ -452,23 +473,42 @@ namespace Captura.ViewModels
                 else OnErrorOccurred(E);
             };
 
-            if (Settings.StartDelay > 0)
+            _waiting = false;
+
+            if (Settings.PreStartCountdown > 0)
             {
-                Task.Factory.StartNew(async () =>
-                {
-                    await Task.Delay(Settings.StartDelay);
+                Status.LocalizationKey = nameof(LanguageManager.Waiting);
 
-                    Status.LocalizationKey = nameof(LanguageManager.Recording);
+                Countdown = Settings.PreStartCountdown;
 
-                    _recorder.Start();
-                });
+                _waiting = true;
             }
-            else _recorder.Start();
+            else InternalStartRecording();
 
             _timing?.Start();
             _timer?.Start();
 
             return true;
+        }
+
+        void InternalStartRecording()
+        {
+            Status.LocalizationKey = nameof(LanguageManager.Recording);
+
+            _recorder.Start();
+        }
+
+        int _countdown;
+
+        public int Countdown
+        {
+            get => _countdown;
+            set
+            {
+                _countdown = value;
+
+                OnPropertyChanged();
+            }
         }
 
         void OnErrorOccurred(Exception E)

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -541,6 +541,8 @@ namespace Captura.ViewModels
             _timer?.Stop();
             _timing.Stop();
 
+            Countdown = 0;
+
             if (Settings.UI.MinimizeOnStart)
                 _mainWindow.IsMinimized = false;
 

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -638,8 +638,11 @@ namespace Captura.ViewModels
 
             RecentItemViewModel savingRecentItem = null;
 
+            // Reference current file name
+            var fileName = _currentFileName;
+
             // Assume saving to file only when extension is present
-            if (!string.IsNullOrWhiteSpace(_videoViewModel.SelectedVideoWriter.Extension))
+            if (!_waiting && !string.IsNullOrWhiteSpace(_videoViewModel.SelectedVideoWriter.Extension))
             {
                 savingRecentItem = _recentViewModel.Add(_currentFileName, _isVideo ? RecentItemType.Video : RecentItemType.Audio, true);
             }
@@ -656,6 +659,9 @@ namespace Captura.ViewModels
 
             AfterRecording();
 
+            var wasWaiting = _waiting;
+            _waiting = false;
+
             try
             {
                 // Ensure saved
@@ -671,6 +677,18 @@ namespace Captura.ViewModels
                 ServiceProvider.MessageProvider.ShowException(e, "Error occurred when stopping recording.\nThis might sometimes occur if you stop recording just as soon as you start it.");
 
                 return;
+            }
+
+            if (wasWaiting)
+            {
+                try
+                {
+                    File.Delete(fileName);
+                }
+                catch
+                {
+                    // Ignore Errors
+                }
             }
 
             if (savingRecentItem != null)

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -477,6 +477,8 @@ namespace Captura.ViewModels
 
             if (Settings.PreStartCountdown > 0)
             {
+                PauseCommand.RaiseCanExecuteChanged(false);
+
                 Status.LocalizationKey = nameof(LanguageManager.Waiting);
 
                 Countdown = Settings.PreStartCountdown;
@@ -496,6 +498,10 @@ namespace Captura.ViewModels
             Status.LocalizationKey = nameof(LanguageManager.Recording);
 
             _recorder.Start();
+
+            if (_syncContext != null)
+                _syncContext.Post(S => PauseCommand.RaiseCanExecuteChanged(true), null);
+            else PauseCommand.RaiseCanExecuteChanged(true);
         }
 
         int _countdown;

--- a/src/Captura/App.xaml
+++ b/src/Captura/App.xaml
@@ -39,6 +39,39 @@
                                      Brush="{DynamicResource ItemText}"/>
                 </DrawingImage.Drawing>
             </DrawingImage>
+
+            <Style x:Key="CountdownLabel" TargetType="Label" BasedOn="{StaticResource {x:Type Label}}">
+                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                <Setter Property="RenderTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleX="1" ScaleY="1"/>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="Visibility" Value="Visible">
+                        <Trigger.EnterActions>
+                            <BeginStoryboard Name="BeginCountdownAnim">
+                                <Storyboard>
+                                    <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX"
+                                                     To="2"
+                                                     Duration="00:00:00.5"
+                                                     AutoReverse="True"
+                                                     RepeatBehavior="Forever"/>
+                                    <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY"
+                                                     To="2"
+                                                     Duration="00:00:00.5"
+                                                     AutoReverse="True"
+                                                     RepeatBehavior="Forever"/>
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </Trigger.EnterActions>
+                        <Trigger.ExitActions>
+                            <StopStoryboard BeginStoryboardName="BeginCountdownAnim"/>
+                        </Trigger.ExitActions>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Captura/Pages/ConfigPage.xaml
+++ b/src/Captura/Pages/ConfigPage.xaml
@@ -48,14 +48,13 @@
                         <RowDefinition/>
                     </Grid.RowDefinitions>
 
-                    <Label Content="{Binding StartDelay, Source={StaticResource Loc}, Mode=OneWay}"
+                    <Label Content="Pre Start Countdown (seconds)"
                            ContentStringFormat="{}{0}: "
                            Margin="0,2,10,2"/>
 
-                    <xctk:IntegerUpDown Value="{Binding Settings.StartDelay, Mode=TwoWay}"
+                    <xctk:IntegerUpDown Value="{Binding Settings.PreStartCountdown, Mode=TwoWay}"
                                         Grid.Column="1"
-                                        Margin="0,2"
-                                        ToolTip="Milliseconds to wait before starting recording"/>
+                                        Margin="0,2"/>
 
                     <Label Content="{Binding CaptureDuration, Source={StaticResource Loc}, Mode=OneWay}"
                            ContentStringFormat="{}{0}: "

--- a/src/Captura/ValueConverters/IsLessThanConverter.cs
+++ b/src/Captura/ValueConverters/IsLessThanConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Data;
 
 namespace Captura
@@ -10,7 +11,12 @@ namespace Captura
         {
             if (double.TryParse(Value?.ToString(), out var left) && double.TryParse(Parameter?.ToString(), out var right))
             {
-                return left < right;
+                var b =  left < right;
+
+                if (TargetType == typeof(Visibility))
+                    return b ? Visibility.Visible : Visibility.Collapsed;
+
+                return b;
             }
 
             return Binding.DoNothing;

--- a/src/Captura/ValueConverters/NegatingConverter.cs
+++ b/src/Captura/ValueConverters/NegatingConverter.cs
@@ -17,15 +17,23 @@ namespace Captura
 
         public object Convert(object Value, Type TargetType, object Parameter, CultureInfo Culture)
         {
-            if (Value is bool b)
+            switch (Value)
             {
-                if (TargetType == typeof(Visibility))
+                case bool b when TargetType == typeof(Visibility):
                     return b ? Visibility.Collapsed : Visibility.Visible;
 
-                return !b;
-            }
+                case bool b:
+                    return !b;
 
-            return Binding.DoNothing;
+                case Visibility visibility when TargetType == typeof(Visibility):
+                    return visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
+
+                case Visibility visibility:
+                    return visibility == Visibility.Collapsed;
+
+                default:
+                    return Binding.DoNothing;
+            }
         }
 
         public object ConvertBack(object Value, Type TargetType, object Parameter, CultureInfo Culture)

--- a/src/Captura/Windows/MainWindow.xaml
+++ b/src/Captura/Windows/MainWindow.xaml
@@ -265,8 +265,38 @@
                     <Grid Margin="0,-2"
                           PreviewMouseLeftButtonDown="Grid_PreviewMouseLeftButtonDown">
                         <Label Content="{Binding RecordingViewModel.TimeSpan}"
+                               Visibility="{Binding RecordingViewModel.Countdown, Converter={StaticResource IsLessThanConverter}, ConverterParameter=1}"
                                Margin="0,-1"
+                               Name="DurationLabel"
                                HorizontalContentAlignment="Center"/>
+
+                        <Label Content="{Binding RecordingViewModel.Countdown}"
+                               Visibility="{Binding Visibility, ElementName=DurationLabel, Converter={StaticResource NegatingConverter}}"
+                               Margin="0,-1"
+                               HorizontalContentAlignment="Center"
+                               RenderTransformOrigin="0.5,0.5">
+                            <Label.RenderTransform>
+                                <ScaleTransform ScaleX="1" ScaleY="1"/>
+                            </Label.RenderTransform>
+                            <Label.Triggers>
+                                <EventTrigger RoutedEvent="Label.Loaded">
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX"
+                                                             To="2"
+                                                             Duration="00:00:00.5"
+                                                             AutoReverse="True"
+                                                             RepeatBehavior="Forever"/>
+                                            <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY"
+                                                             To="2"
+                                                             Duration="00:00:00.5"
+                                                             AutoReverse="True"
+                                                             RepeatBehavior="Forever"/>
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </EventTrigger>
+                            </Label.Triggers>
+                        </Label>
                     </Grid>
                 </DockPanel>
             </Expander.Header>

--- a/src/Captura/Windows/MainWindow.xaml
+++ b/src/Captura/Windows/MainWindow.xaml
@@ -273,6 +273,7 @@
                         <Label Visibility="{Binding Visibility, ElementName=DurationLabel, Converter={StaticResource NegatingConverter}}"
                                Margin="0,-1"
                                Style="{StaticResource CountdownLabel}"
+                               HorizontalAlignment="Center"
                                Content="{Binding RecordingViewModel.Countdown}"/>
                     </Grid>
                 </DockPanel>

--- a/src/Captura/Windows/MainWindow.xaml
+++ b/src/Captura/Windows/MainWindow.xaml
@@ -270,44 +270,10 @@
                                Name="DurationLabel"
                                HorizontalContentAlignment="Center"/>
 
-                        <Label Content="{Binding RecordingViewModel.Countdown}"
-                               Visibility="{Binding Visibility, ElementName=DurationLabel, Converter={StaticResource NegatingConverter}}"
+                        <Label Visibility="{Binding Visibility, ElementName=DurationLabel, Converter={StaticResource NegatingConverter}}"
                                Margin="0,-1"
-                               HorizontalContentAlignment="Center"
-                               RenderTransformOrigin="0.5,0.5">
-                            <Label.Style>
-                                <Style TargetType="Label" BasedOn="{StaticResource {x:Type Label}}">
-                                    <Setter Property="RenderTransform">
-                                        <Setter.Value>
-                                            <ScaleTransform ScaleX="1" ScaleY="1"/>
-                                        </Setter.Value>
-                                    </Setter>
-                                    <Style.Triggers>
-                                        <Trigger Property="Visibility" Value="Visible">
-                                            <Trigger.EnterActions>
-                                                <BeginStoryboard Name="BeginCountdownAnim">
-                                                    <Storyboard>
-                                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX"
-                                                                         To="2"
-                                                                         Duration="00:00:00.5"
-                                                                         AutoReverse="True"
-                                                                         RepeatBehavior="Forever"/>
-                                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY"
-                                                                         To="2"
-                                                                         Duration="00:00:00.5"
-                                                                         AutoReverse="True"
-                                                                         RepeatBehavior="Forever"/>
-                                                    </Storyboard>
-                                                </BeginStoryboard>
-                                            </Trigger.EnterActions>
-                                            <Trigger.ExitActions>
-                                                <StopStoryboard BeginStoryboardName="BeginCountdownAnim"/>
-                                            </Trigger.ExitActions>
-                                        </Trigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Label.Style>
-                        </Label>
+                               Style="{StaticResource CountdownLabel}"
+                               Content="{Binding RecordingViewModel.Countdown}"/>
                     </Grid>
                 </DockPanel>
             </Expander.Header>

--- a/src/Captura/Windows/MainWindow.xaml
+++ b/src/Captura/Windows/MainWindow.xaml
@@ -275,27 +275,38 @@
                                Margin="0,-1"
                                HorizontalContentAlignment="Center"
                                RenderTransformOrigin="0.5,0.5">
-                            <Label.RenderTransform>
-                                <ScaleTransform ScaleX="1" ScaleY="1"/>
-                            </Label.RenderTransform>
-                            <Label.Triggers>
-                                <EventTrigger RoutedEvent="Label.Loaded">
-                                    <BeginStoryboard>
-                                        <Storyboard>
-                                            <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX"
-                                                             To="2"
-                                                             Duration="00:00:00.5"
-                                                             AutoReverse="True"
-                                                             RepeatBehavior="Forever"/>
-                                            <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY"
-                                                             To="2"
-                                                             Duration="00:00:00.5"
-                                                             AutoReverse="True"
-                                                             RepeatBehavior="Forever"/>
-                                        </Storyboard>
-                                    </BeginStoryboard>
-                                </EventTrigger>
-                            </Label.Triggers>
+                            <Label.Style>
+                                <Style TargetType="Label" BasedOn="{StaticResource {x:Type Label}}">
+                                    <Setter Property="RenderTransform">
+                                        <Setter.Value>
+                                            <ScaleTransform ScaleX="1" ScaleY="1"/>
+                                        </Setter.Value>
+                                    </Setter>
+                                    <Style.Triggers>
+                                        <Trigger Property="Visibility" Value="Visible">
+                                            <Trigger.EnterActions>
+                                                <BeginStoryboard Name="BeginCountdownAnim">
+                                                    <Storyboard>
+                                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX"
+                                                                         To="2"
+                                                                         Duration="00:00:00.5"
+                                                                         AutoReverse="True"
+                                                                         RepeatBehavior="Forever"/>
+                                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY"
+                                                                         To="2"
+                                                                         Duration="00:00:00.5"
+                                                                         AutoReverse="True"
+                                                                         RepeatBehavior="Forever"/>
+                                                    </Storyboard>
+                                                </BeginStoryboard>
+                                            </Trigger.EnterActions>
+                                            <Trigger.ExitActions>
+                                                <StopStoryboard BeginStoryboardName="BeginCountdownAnim"/>
+                                            </Trigger.ExitActions>
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Label.Style>
                         </Label>
                     </Grid>
                 </DockPanel>

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -265,11 +265,11 @@
                            HorizontalContentAlignment="Center"
                            PreviewMouseLeftButtonDown="UIElement_OnPreviewMouseLeftButtonDown"/>
 
-                    <Label Content="{Binding RecordingViewModel.Countdown}"
-                           Visibility="{Binding Visibility, ElementName=DurationLabel, Converter={StaticResource NegatingConverter}}"
+                    <Label Visibility="{Binding Visibility, ElementName=DurationLabel, Converter={StaticResource NegatingConverter}}"
+                           Content="{Binding RecordingViewModel.Countdown}"
                            Margin="10,-1"
-                           HorizontalContentAlignment="Center"
-                           PreviewMouseLeftButtonDown="UIElement_OnPreviewMouseLeftButtonDown"/>
+                           PreviewMouseLeftButtonDown="UIElement_OnPreviewMouseLeftButtonDown"
+                           Style="{StaticResource CountdownLabel}"/>
                 </DockPanel>
             </Border>
         </Grid>

--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -259,6 +259,14 @@
                     </local:ModernButton>
 
                     <Label Content="{Binding RecordingViewModel.TimeSpan}"
+                           Visibility="{Binding RecordingViewModel.Countdown, Converter={StaticResource IsLessThanConverter}, ConverterParameter=1}"
+                           Margin="10,-1"
+                           Name="DurationLabel"
+                           HorizontalContentAlignment="Center"
+                           PreviewMouseLeftButtonDown="UIElement_OnPreviewMouseLeftButtonDown"/>
+
+                    <Label Content="{Binding RecordingViewModel.Countdown}"
+                           Visibility="{Binding Visibility, ElementName=DurationLabel, Converter={StaticResource NegatingConverter}}"
                            Margin="10,-1"
                            HorizontalContentAlignment="Center"
                            PreviewMouseLeftButtonDown="UIElement_OnPreviewMouseLeftButtonDown"/>


### PR DESCRIPTION
Changing the `Start Delay (milliseconds)` option to `Pre-Start Countdown` which is specified in `seconds`.

Animated Countdown is displayed before recording in place of duration.