### PR TITLE
Fix coordinate transform for full screen items

### DIFF
--- a/src/Screna/VideoItems/FullScreenItem.cs
+++ b/src/Screna/VideoItems/FullScreenItem.cs
@@ -13,9 +13,9 @@ namespace Captura.Models
 
         public IImageProvider GetImageProvider(bool IncludeCursor, out Func<Point, Point> Transform)
         {
-            Transform = P => P;
-
-            return new RegionProvider(WindowProvider.DesktopRectangle, IncludeCursor);
-        }
+			Rectangle region = WindowProvider.DesktopRectangle;
+			Transform = P => new Point(P.X - region.X, P.Y - region.Y);
+			return new RegionProvider(region, IncludeCursor);
+		}
     }
 }


### PR DESCRIPTION
When capturing with multiple monitors mouse click overlay positions are not correct.
We need to transform the FullScreenItems like cursor position.

I have added two recordings showing the results before and after this fix.

[Captura.zip](https://github.com/MathewSachin/Captura/files/2460271/Captura.zip)

