### PR TITLE
Customizable Tray Left Click Action

### DIFF
--- a/src/Captura.Core/Settings/Models/VisualSettings.cs
+++ b/src/Captura.Core/Settings/Models/VisualSettings.cs
@@ -79,5 +79,11 @@
             get => Get("en");
             set => Set(value);
         }
+
+        public ServiceName TrayLeftClickAction
+        {
+            get => Get(ServiceName.ShowMainWindow);
+            set => Set(value);
+        }
     }
 }

--- a/src/Captura.Core/ViewModels/MainViewModel.cs
+++ b/src/Captura.Core/ViewModels/MainViewModel.cs
@@ -39,6 +39,8 @@ namespace Captura.ViewModels
         public DelegateCommand SelectFFmpegFolderCommand { get; } = new DelegateCommand(FFmpegService.SelectFFmpegFolder);
 
         public DelegateCommand ResetFFmpegFolderCommand { get; }
+
+        public DelegateCommand TrayLeftClickCommand { get; }
         #endregion
 
         public MainViewModel(AudioSource AudioSource,
@@ -75,6 +77,8 @@ namespace Captura.ViewModels
             SelectOutputFolderCommand = new DelegateCommand(SelectOutputFolder);
 
             ResetFFmpegFolderCommand = new DelegateCommand(() => Settings.FFmpeg.FolderPath = "");
+
+            TrayLeftClickCommand = new DelegateCommand(() => HotKeyManager.FakeHotkey(Settings.UI.TrayLeftClickAction));
             #endregion
 
             Settings.Audio.PropertyChanged += (Sender, Args) =>

--- a/src/Captura.Hotkeys/HotKeyManager.cs
+++ b/src/Captura.Hotkeys/HotKeyManager.cs
@@ -142,6 +142,11 @@ namespace Captura
                 HotkeyPressed?.Invoke(hotkey.Service.ServiceName);
         }
 
+        public void FakeHotkey(ServiceName Service)
+        {
+            HotkeyPressed?.Invoke(Service);
+        }
+
         public event Action<ServiceName> HotkeyPressed;
         
         public void Dispose()

--- a/src/Captura.Loc/LanguageFields.cs
+++ b/src/Captura.Loc/LanguageFields.cs
@@ -157,6 +157,12 @@ namespace Captura
             set => Set(value);
         }
 
+        public string ConfigTrayIcon
+        {
+            get => Get();
+            set => Set(value);
+        }
+
         public string Configure
         {
             get => Get();

--- a/src/Captura.Loc/Languages/en.json
+++ b/src/Captura.Loc/Languages/en.json
@@ -21,6 +21,7 @@
   "ConfigCodecs": "Configure Codecs",
   "ConfigFileNaming": "Configure File Naming",
   "ConfigSounds": "Configure Sounds",
+  "ConfigTrayIcon": "Configure Tray Icon",
   "Configure": "Configure",
   "CopyOutPathClipboard": "Copy Output file path to Clipboard",
   "CopyPath": "Copy Path",

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -110,6 +110,9 @@
     <Compile Include="Pages\ScreenShotsPage.xaml.cs">
       <DependentUpon>ScreenShotsPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Windows\TrayConfigWindow.xaml.cs">
+      <DependentUpon>TrayConfigWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Windows\SoundsWindow.xaml.cs">
       <DependentUpon>SoundsWindow.xaml</DependentUpon>
     </Compile>
@@ -305,6 +308,10 @@
     <Page Include="Presentation\Themes\VirtualizingItemsControl.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Windows\TrayConfigWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Windows\SoundsWindow.xaml">
       <SubType>Designer</SubType>

--- a/src/Captura/Pages/ConfigPage.xaml
+++ b/src/Captura/Pages/ConfigPage.xaml
@@ -74,24 +74,6 @@
                                Text="{Binding MinCapture, Source={StaticResource Loc}, Mode=OneWay}"/>
                 </CheckBox>
 
-                <CheckBox IsChecked="{Binding Settings.UI.MinToTrayOnStartup}"
-                          Margin="0,2">
-                    <TextBlock TextWrapping="Wrap"
-                               Text="{Binding MinTrayStartup, Source={StaticResource Loc}, Mode=OneWay}"/>
-                </CheckBox>
-
-                <CheckBox IsChecked="{Binding Settings.UI.MinToTrayOnClose}"
-                          Margin="0,2">
-                    <TextBlock TextWrapping="Wrap"
-                               Text="{Binding MinTrayClose, Source={StaticResource Loc}, Mode=OneWay}"/>
-                </CheckBox>
-
-                <CheckBox IsChecked="{Binding Settings.UI.TrayNotify}"
-                          Margin="0,2">
-                    <TextBlock TextWrapping="Wrap"
-                               Text="{Binding ShowSysNotify, Source={StaticResource Loc}, Mode=OneWay}"/>
-                </CheckBox>
-
                 <CheckBox IsChecked="{Binding Settings.CopyOutPathToClipboard}"
                           Margin="0,2">
                     <TextBlock TextWrapping="Wrap"

--- a/src/Captura/Pages/ConfigPage.xaml
+++ b/src/Captura/Pages/ConfigPage.xaml
@@ -101,7 +101,13 @@
                 <CheckBox Content="{Binding AlwaysOnTop, Source={StaticResource Loc}, Mode=OneWay}"
                           IsChecked="{Binding Settings.UI.MainWindowTopmost}"
                           Margin="0,2"/>
-                
+
+                <Button Margin="0,2"
+                        ContentStringFormat="{}{0} ..."
+                        Content="{Binding ConfigTrayIcon, Source={StaticResource Loc}, Mode=OneWay}"
+                        Click="OpenTrayIconConfig"
+                        IsEnabled="{Binding RecordingViewModel.RecorderState, Converter={StaticResource NotRecordingConverter}}"/>
+
                 <Button Margin="0,2"
                         ContentStringFormat="{}{0} ..."
                         Content="{Binding ConfigFileNaming, Source={StaticResource Loc}, Mode=OneWay}"

--- a/src/Captura/Pages/ConfigPage.xaml.cs
+++ b/src/Captura/Pages/ConfigPage.xaml.cs
@@ -24,5 +24,10 @@ namespace Captura
         {
             new SoundsWindow().ShowDialog();
         }
+
+        void OpenTrayIconConfig(object Sender, RoutedEventArgs E)
+        {
+            new TrayConfigWindow().ShowDialog();
+        }
     }
 }

--- a/src/Captura/Windows/MainWindow.xaml
+++ b/src/Captura/Windows/MainWindow.xaml
@@ -46,12 +46,8 @@
                         IconSource="{Binding RecordingViewModel.RecorderState, Converter={StaticResource StateToTrayIconSourceConverter}}"
                         ToolTipText="Captura"
                         MenuActivation="RightClick"
-                        LeftClickCommand="Favorites"
+                        LeftClickCommand="{Binding TrayLeftClickCommand}"
                         TrayMouseDoubleClick="SystemTray_TrayMouseDoubleClick">
-            <tb:TaskbarIcon.CommandBindings>
-                <CommandBinding Command="Favorites"
-                                Executed="TrayLeftClick"/>
-            </tb:TaskbarIcon.CommandBindings>
             <tb:TaskbarIcon.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="{Binding StartStopRecording, Source={StaticResource Loc}, Mode=OneWay}"

--- a/src/Captura/Windows/MainWindow.xaml
+++ b/src/Captura/Windows/MainWindow.xaml
@@ -45,8 +45,13 @@
         <tb:TaskbarIcon x:Name="SystemTray"
                         IconSource="{Binding RecordingViewModel.RecorderState, Converter={StaticResource StateToTrayIconSourceConverter}}"
                         ToolTipText="Captura"
-                        MenuActivation="LeftOrRightClick"
+                        MenuActivation="RightClick"
+                        LeftClickCommand="Favorites"
                         TrayMouseDoubleClick="SystemTray_TrayMouseDoubleClick">
+            <tb:TaskbarIcon.CommandBindings>
+                <CommandBinding Command="Favorites"
+                                Executed="TrayLeftClick"/>
+            </tb:TaskbarIcon.CommandBindings>
             <tb:TaskbarIcon.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="{Binding StartStopRecording, Source={StaticResource Loc}, Mode=OneWay}"
@@ -171,6 +176,23 @@
                     </MenuItem>
 
                     <Separator/>
+
+                    <MenuItem Header="Show Main Window"
+                              Click="ShowMainWindow">
+                        <MenuItem.Icon>
+                            <Image Width="13"
+                                   Margin="5">
+                                <Image.Source>
+                                    <DrawingImage>
+                                        <DrawingImage.Drawing>
+                                            <GeometryDrawing Geometry="{StaticResource IconWindow}"
+                                                             Brush="{DynamicResource ItemText}"/>
+                                        </DrawingImage.Drawing>
+                                    </DrawingImage>
+                                </Image.Source>
+                            </Image>
+                        </MenuItem.Icon>
+                    </MenuItem>
 
                     <MenuItem Header="{Binding Exit, Source={StaticResource Loc}, Mode=OneWay}"
                               Click="MenuExit_Click">

--- a/src/Captura/Windows/MainWindow.xaml.cs
+++ b/src/Captura/Windows/MainWindow.xaml.cs
@@ -154,10 +154,5 @@ namespace Captura
         {
             this.ShowAndFocus();
         }
-
-        void TrayLeftClick(object Sender, ExecutedRoutedEventArgs E)
-        {
-            this.ShowAndFocus();
-        }
     }
 }

--- a/src/Captura/Windows/MainWindow.xaml.cs
+++ b/src/Captura/Windows/MainWindow.xaml.cs
@@ -149,5 +149,15 @@ namespace Captura
         void MenuExit_Click(object Sender, RoutedEventArgs Args) => Close();
 
         void HideButton_Click(object Sender, RoutedEventArgs Args) => Hide();
+
+        void ShowMainWindow(object Sender, RoutedEventArgs E)
+        {
+            this.ShowAndFocus();
+        }
+
+        void TrayLeftClick(object Sender, ExecutedRoutedEventArgs E)
+        {
+            this.ShowAndFocus();
+        }
     }
 }

--- a/src/Captura/Windows/TrayConfigWindow.xaml
+++ b/src/Captura/Windows/TrayConfigWindow.xaml
@@ -5,6 +5,7 @@
         Title="{Binding ConfigTrayIcon, Source={StaticResource Loc}, Mode=OneWay}"
         Height="450"
         Width="600"
+        ResizeMode="NoResize"
         DataContext="{Binding MainViewModel, Source={StaticResource ServiceLocator}}">
     <Grid Margin="10">
         <StackPanel>
@@ -26,7 +27,7 @@
                            Text="{Binding ShowSysNotify, Source={StaticResource Loc}, Mode=OneWay}"/>
             </CheckBox>
 
-            <DockPanel Margin="0,5">
+            <DockPanel Margin="0,10">
                 <Label Content="Left Click Action"
                        Margin="0,0,10,0"/>
 

--- a/src/Captura/Windows/TrayConfigWindow.xaml
+++ b/src/Captura/Windows/TrayConfigWindow.xaml
@@ -1,0 +1,10 @@
+﻿<Window x:Class="Captura.TrayConfigWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="{Binding ConfigTrayIcon, Source={StaticResource Loc}, Mode=OneWay}"
+        Height="450"
+        Width="600">
+    <Grid>
+        
+    </Grid>
+</Window>

--- a/src/Captura/Windows/TrayConfigWindow.xaml
+++ b/src/Captura/Windows/TrayConfigWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="Captura.TrayConfigWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:hotkeys="clr-namespace:Captura;assembly=Captura.Hotkeys"
         Title="{Binding ConfigTrayIcon, Source={StaticResource Loc}, Mode=OneWay}"
         Height="450"
         Width="600"
@@ -24,6 +25,16 @@
                 <TextBlock TextWrapping="Wrap"
                            Text="{Binding ShowSysNotify, Source={StaticResource Loc}, Mode=OneWay}"/>
             </CheckBox>
+
+            <DockPanel Margin="0,5">
+                <Label Content="Left Click Action"
+                       Margin="0,0,10,0"/>
+
+                <ComboBox SelectedValue="{Binding Settings.UI.TrayLeftClickAction, Mode=TwoWay}"
+                          SelectedValuePath="ServiceName"
+                          DisplayMemberPath="Description.Display"
+                          ItemsSource="{x:Static hotkeys:HotKeyManager.AllServices}"/>
+            </DockPanel>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/Captura/Windows/TrayConfigWindow.xaml
+++ b/src/Captura/Windows/TrayConfigWindow.xaml
@@ -3,8 +3,27 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="{Binding ConfigTrayIcon, Source={StaticResource Loc}, Mode=OneWay}"
         Height="450"
-        Width="600">
-    <Grid>
-        
+        Width="600"
+        DataContext="{Binding MainViewModel, Source={StaticResource ServiceLocator}}">
+    <Grid Margin="10">
+        <StackPanel>
+            <CheckBox IsChecked="{Binding Settings.UI.MinToTrayOnStartup}"
+                      Margin="0,2">
+                <TextBlock TextWrapping="Wrap"
+                           Text="{Binding MinTrayStartup, Source={StaticResource Loc}, Mode=OneWay}"/>
+            </CheckBox>
+
+            <CheckBox IsChecked="{Binding Settings.UI.MinToTrayOnClose}"
+                      Margin="0,2">
+                <TextBlock TextWrapping="Wrap"
+                           Text="{Binding MinTrayClose, Source={StaticResource Loc}, Mode=OneWay}"/>
+            </CheckBox>
+
+            <CheckBox IsChecked="{Binding Settings.UI.TrayNotify}"
+                      Margin="0,2">
+                <TextBlock TextWrapping="Wrap"
+                           Text="{Binding ShowSysNotify, Source={StaticResource Loc}, Mode=OneWay}"/>
+            </CheckBox>
+        </StackPanel>
     </Grid>
 </Window>

--- a/src/Captura/Windows/TrayConfigWindow.xaml.cs
+++ b/src/Captura/Windows/TrayConfigWindow.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Captura
+{
+    public partial class TrayConfigWindow
+    {
+        public TrayConfigWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
- Added a new window for configuring system tray icon and moved relevant settings there.
- Added a `Show Main Window` action in tray context menu.
- Left click action for the tray icon can be customised the same way as Hotkeys. It is set by default to `Show Main Window`.

Related to #299