### PR TITLE
NAudio support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ TestResults/
 
 /temp/
 /dist/
+*.pfx

--- a/licenses/BASS.txt
+++ b/licenses/BASS.txt
@@ -1,0 +1,83 @@
+Licence
+=======
+BASS is free for non-commercial use. If you are a non-commercial entity
+(eg. an individual) and you are not making any money from your product
+(through sales/advertising/etc), then you can use BASS in it for free.
+If you wish to use BASS in commercial products, then please also see the
+next section.
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, BASS IS PROVIDED
+"AS IS", WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND/OR FITNESS FOR A PARTICULAR PURPOSE. THE AUTHORS SHALL NOT BE HELD
+LIABLE FOR ANY DAMAGE THAT MAY RESULT FROM THE USE OF BASS. YOU USE
+BASS ENTIRELY AT YOUR OWN RISK.
+
+Usage of BASS indicates that you agree to the above conditions.
+
+All trademarks and other registered names contained in the BASS
+package are the property of their respective owners.
+
+Commercial licensing
+--------------------
+BASS is available for use in your commercial products. The licence
+types available are as follows:
+
+SHAREWARE: Allows the usage of BASS in an unlimited number of your
+shareware ("try before you buy") products, which must sell for no more
+than 40 Euros each. Non-shareware products are also permitted, but the
+product price limit is 10 Euros in that case. The price limit can be
+raised by purchasing duplicate licences, eg. 2 licences doubles it. If
+you are an individual (not a corporation) making and selling your own
+software, this is the licence for you. 
+
+SINGLE COMMERCIAL: Allows the usage of BASS in one commercial product.
+
+UNLIMITED COMMERCIAL: Allows the usage of BASS in an unlimited number
+of your commercial products. This licence is on a per-site basis, eg.
+if you are creating products with BASS at 2 sites/locations, then 2
+licences are required.
+
+Please note the products must be end-user products, eg. not components
+used by other products. 
+
+These licences only cover your own software, not the publishing of
+other's software. If you publish other's software, its developers (or
+the software itself) will need to be licensed to use BASS.
+
+These licences are on a per-platform basis, with reductions available
+when licensing for multiple platforms. In all cases there are no royalties
+to pay, and you can use future BASS updates without further cost.
+
+These licences do not allow reselling/sublicensing of BASS. For example,
+if a product is a development system, the users of said product are not
+licensed to use BASS in their productions; they will need their own
+licences.
+
+If the standard licences do not meet your requirements, or if you have
+any questions, please get in touch (email: bass@un4seen.com).
+
+Visit the BASS website for the latest pricing:
+
+	www.un4seen.com
+
+MP3
+---
+MP3 technology is patented, and Thomson license the use of their and
+Fraunhofer's patents. The inclusion of an MP3 decoder (eg. BASS) in a
+commercial product requires an MP3 patent licence. Contact Thomson for
+details:
+
+	www.mp3licensing.com
+
+Alternatively, the "MP3-FREE" BASS version does not include its own MP3
+decoder but instead makes use of the operating system's already licensed
+decoder. If an MP3 decoder is not available, then MP3 playback will not
+be possible, but everything else will function as normal.
+
+NOTE: When using the OS's MP3 decoder, BASS still does the file handling
+      so all the usual features are still supported, including streaming,
+      tag reading, pre-scanning, gapless playback, etc.
+
+NOTE: Linux does not include an MP3 decoder as standard. The "MP3-FREE"
+      BASS version will make use of the libmpg123 decoder, if installed.

--- a/licenses/NAudio.txt
+++ b/licenses/NAudio.txt
@@ -1,0 +1,31 @@
+Microsoft Public License (Ms-PL)
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.
+
+1. Definitions
+
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+
+A "contributor" is any person that distributes its contribution under this license.
+
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
+
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
+
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
+
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement. 

--- a/src/Captura.Base/Audio/AudioSource.cs
+++ b/src/Captura.Base/Audio/AudioSource.cs
@@ -33,5 +33,7 @@ namespace Captura.Models
         public abstract IAudioProvider GetMixedAudioProvider();
 
         public abstract IAudioProvider[] GetMultipleAudioProviders();
+
+        public abstract string Name { get; }
     }
 }

--- a/src/Captura.Base/Audio/AudioSource.cs
+++ b/src/Captura.Base/Audio/AudioSource.cs
@@ -35,5 +35,7 @@ namespace Captura.Models
         public abstract IAudioProvider[] GetMultipleAudioProviders();
 
         public abstract string Name { get; }
+
+        public virtual bool CanChangeSourcesDuringRecording => false;
     }
 }

--- a/src/Captura.Base/Settings/AudioSettings.cs
+++ b/src/Captura.Base/Settings/AudioSettings.cs
@@ -31,11 +31,5 @@
             get => Get(50);
             set => Set(value);
         }
-
-        public bool PlaybackRecordingRealTime
-        {
-            get => Get(false);
-            set => Set(value);
-        }
     }
 }

--- a/src/Captura.Bass/BassAudioSource.cs
+++ b/src/Captura.Bass/BassAudioSource.cs
@@ -38,9 +38,7 @@ namespace Captura.Models
         {
             return new MixedAudioProvider(AvailableRecordingSources
                 .Concat(AvailableLoopbackSources)
-                .Cast<BassItem>(),
-                !_settings.PlaybackRecordingRealTime
-                );
+                .Cast<BassItem>());
         }
 
         public override IAudioProvider[] GetMultipleAudioProviders()

--- a/src/Captura.Bass/BassAudioSource.cs
+++ b/src/Captura.Bass/BassAudioSource.cs
@@ -83,5 +83,7 @@ namespace Captura.Models
                 }
             }
         }
+
+        public override string Name { get; } = "BASS";
     }
 }

--- a/src/Captura.Bass/BassAudioSource.cs
+++ b/src/Captura.Bass/BassAudioSource.cs
@@ -11,12 +11,8 @@ namespace Captura.Models
     // ReSharper disable once ClassNeverInstantiated.Global
     public class BassAudioSource : AudioSource
     {
-        readonly AudioSettings _settings;
-
-        public BassAudioSource(AudioSettings Settings)
+        public BassAudioSource()
         {
-            _settings = Settings;
-
             // Initialises Default Playback Device.
             Bass.Init();
 
@@ -85,5 +81,7 @@ namespace Captura.Models
         }
 
         public override string Name { get; } = "BASS";
+
+        public override bool CanChangeSourcesDuringRecording => true;
     }
 }

--- a/src/Captura.Bass/MixedAudioProvider.cs
+++ b/src/Captura.Bass/MixedAudioProvider.cs
@@ -32,7 +32,7 @@ namespace Captura.Models
         /// <summary>
         /// Creates a new instance of <see cref="MixedAudioProvider"/>.
         /// </summary>
-        public MixedAudioProvider(IEnumerable<BassItem> Devices, bool MuteOutput = true)
+        public MixedAudioProvider(IEnumerable<BassItem> Devices)
         {
             if (Devices == null)
                 throw new ArgumentNullException();
@@ -49,11 +49,8 @@ namespace Captura.Models
                 InitDevice(recordingDevice);
             }
 
-            if (MuteOutput)
-            {
-                // mute the mixer
-                Bass.ChannelSetAttribute(_mixer, ChannelAttribute.Volume, 0);
-            }
+            // mute the mixer
+            Bass.ChannelSetAttribute(_mixer, ChannelAttribute.Volume, 0);
 
             Bass.ChannelSetDSP(_mixer, Procedure);
         }

--- a/src/Captura.Core/Captura.Core.csproj
+++ b/src/Captura.Core/Captura.Core.csproj
@@ -132,6 +132,10 @@
       <Project>{81F2E68E-4708-4D52-8419-51888F22D05E}</Project>
       <Name>Captura.Native</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Captura.NAudio\Captura.NAudio.csproj">
+      <Project>{76bc6324-e205-41db-b60a-128d9fd66624}</Project>
+      <Name>Captura.NAudio</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Captura.SharpAvi\Captura.SharpAvi.csproj">
       <Project>{bb8ff9f8-ec60-4a4a-a3f0-d9fbfb585d86}</Project>
       <Name>Captura.SharpAvi</Name>

--- a/src/Captura.Core/CoreModule.cs
+++ b/src/Captura.Core/CoreModule.cs
@@ -1,4 +1,5 @@
 ﻿using Captura.Models;
+using Captura.NAudio;
 using Captura.ViewModels;
 
 namespace Captura
@@ -85,11 +86,12 @@ namespace Captura
             Binder.Bind<IRecentItemSerializer, ImgurRecentSerializer>();
 
             // Check if Bass is available
-            if (BassAudioSource.Available)
-            {
-                Binder.Bind<AudioSource, BassAudioSource>();
-            }
-            else Binder.Bind<AudioSource, NoAudioSource>();
+            //if (BassAudioSource.Available)
+            //{
+            //    Binder.Bind<AudioSource, BassAudioSource>();
+            //}
+            //else Binder.Bind<AudioSource, NoAudioSource>();
+            Binder.Bind<AudioSource, NAudioSource>();
         }
     }
 }

--- a/src/Captura.Core/CoreModule.cs
+++ b/src/Captura.Core/CoreModule.cs
@@ -86,12 +86,11 @@ namespace Captura
             Binder.Bind<IRecentItemSerializer, ImgurRecentSerializer>();
 
             // Check if Bass is available
-            //if (BassAudioSource.Available)
-            //{
-            //    Binder.Bind<AudioSource, BassAudioSource>();
-            //}
-            //else Binder.Bind<AudioSource, NoAudioSource>();
-            Binder.Bind<AudioSource, NAudioSource>();
+            if (BassAudioSource.Available)
+            {
+                Binder.Bind<AudioSource, BassAudioSource>();
+            }
+            else Binder.Bind<AudioSource, NAudioSource>();
         }
     }
 }

--- a/src/Captura.Core/Models/NoAudioSource.cs
+++ b/src/Captura.Core/Models/NoAudioSource.cs
@@ -12,5 +12,7 @@ namespace Captura.Models
         public override IAudioProvider[] GetMultipleAudioProviders() => new IAudioProvider[0];
 
         protected override void OnRefresh() { }
+
+        public override string Name { get; } = "No Audio";
     }
 }

--- a/src/Captura.Core/ViewModels/MainViewModel.cs
+++ b/src/Captura.Core/ViewModels/MainViewModel.cs
@@ -224,12 +224,6 @@ namespace Captura.ViewModels
             }
 
             HotKeyManager.ShowNotRegisteredOnStartup();
-
-            if (AudioSource is NoAudioSource)
-            {
-                ServiceProvider.MessageProvider.ShowError(
-                    "Could not find bass.dll or bassmix.dll.\nAudio Recording will not be available.", "No Audio");
-            }
         }
         
         public void Dispose()

--- a/src/Captura.Core/ViewModels/RecordingViewModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingViewModel.cs
@@ -116,7 +116,7 @@ namespace Captura.ViewModels
         public bool CanChangeWebcam
         {
             get => _canChangeWebcam;
-            set
+            private set
             {
                 _canChangeWebcam = value;
 
@@ -127,7 +127,7 @@ namespace Captura.ViewModels
         public bool CanChangeAudioSources
         {
             get => _canChangeAudioSources;
-            set
+            private set
             {
                 _canChangeAudioSources = value;
                 
@@ -448,7 +448,8 @@ namespace Captura.ViewModels
             RecorderState = RecorderState.Recording;
 
             CanChangeWebcam = !Settings.WebcamOverlay.SeparateFile;
-            CanChangeAudioSources = !Settings.Audio.SeparateFilePerSource;
+
+            CanChangeAudioSources = !Settings.Audio.SeparateFilePerSource && _audioSource.CanChangeSourcesDuringRecording;
 
             _timer?.Stop();
             TimeSpan = TimeSpan.Zero;

--- a/src/Captura.Loc/LanguageFields.cs
+++ b/src/Captura.Loc/LanguageFields.cs
@@ -625,12 +625,6 @@ namespace Captura
             set => Set(value);
         }
 
-        public string PlayRecAudio
-        {
-            get => Get();
-            set => Set(value);
-        }
-
         public string Port
         {
             get => Get();

--- a/src/Captura.Loc/Languages/en.json
+++ b/src/Captura.Loc/Languages/en.json
@@ -124,7 +124,7 @@
   "ScreenShotSaved": "ScreenShot Saved",
   "SelectFFmpegFolder": "Select FFmpeg Folder",
   "SelectOutFolder": "Select Output Folder",
-  "SeparateAudioFiles": "Separate files for every audio source",
+  "SeparateAudioFiles": "Separate file for every audio source",
   "ShowSysNotify": "Show System Tray Notifications",
   "SnapToWindow": "Snap to Window",
   "Sounds": "Sounds",

--- a/src/Captura.Loc/Languages/en.json
+++ b/src/Captura.Loc/Languages/en.json
@@ -99,7 +99,6 @@
   "Paused": "Recording Paused",
   "PauseResume": "Pause | Resume",
   "PauseResumeRecording": "Pause/Resume Recording",
-  "PlayRecAudio": "Playback recorded audio in real-time",
   "Port": "Port",
   "Preview": "Preview",
   "PreStartCountdown": "Pre Start Countdown (seconds)",

--- a/src/Captura.NAudio/Captura.NAudio.csproj
+++ b/src/Captura.NAudio/Captura.NAudio.csproj
@@ -35,7 +35,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NAudioItem.cs" />
+    <Compile Include="NAudioProvider.cs" />
     <Compile Include="NAudioSource.cs" />
+    <Compile Include="WasapiCaptureProvider.cs" />
+    <Compile Include="WasapiLoopbackCaptureProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Captura.NAudio/Captura.NAudio.csproj
+++ b/src/Captura.NAudio/Captura.NAudio.csproj
@@ -34,6 +34,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MixedAudioProvider.cs" />
     <Compile Include="NAudioItem.cs" />
     <Compile Include="NAudioProvider.cs" />
     <Compile Include="NAudioSource.cs" />

--- a/src/Captura.NAudio/Captura.NAudio.csproj
+++ b/src/Captura.NAudio/Captura.NAudio.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{76BC6324-E205-41DB-B60A-128D9FD66624}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Captura.NAudio</RootNamespace>
+    <AssemblyName>Captura.NAudio</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NAudioItem.cs" />
+    <Compile Include="NAudioSource.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Captura.Base\Captura.Base.csproj">
+      <Project>{388d8b28-e629-4684-8537-8d78719b69e5}</Project>
+      <Name>Captura.Base</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NAudio">
+      <Version>1.8.5</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Captura.NAudio/MixedAudioProvider.cs
+++ b/src/Captura.NAudio/MixedAudioProvider.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using Captura.Audio;
+
+namespace Captura.NAudio
+{
+    // TODO: Make this work ;-(
+    class MixedAudioProvider : IAudioProvider
+    {
+        readonly IEnumerable<NAudioProvider> _audioProviders;
+
+        public MixedAudioProvider(IEnumerable<NAudioProvider> AudioProviders)
+        {
+            _audioProviders = AudioProviders;
+        }
+
+        public void Dispose()
+        {
+            foreach (var provider in _audioProviders)
+            {
+                provider.Dispose();
+            }
+        }
+
+        public WaveFormat WaveFormat { get; } = WaveFormat.CreateIeeeFloatWaveFormat(44100, 2);
+
+        public void Start()
+        {
+            foreach (var provider in _audioProviders)
+            {
+                provider.Start();
+            }
+        }
+
+        public void Stop()
+        {
+            foreach (var provider in _audioProviders)
+            {
+                provider.Stop();
+            }
+        }
+
+        public event EventHandler<DataAvailableEventArgs> DataAvailable;
+    }
+}

--- a/src/Captura.NAudio/MixedAudioProvider.cs
+++ b/src/Captura.NAudio/MixedAudioProvider.cs
@@ -1,22 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
 using Captura.Audio;
+using NAudio.Wave;
+using WaveFormat = Captura.Audio.WaveFormat;
+using Wf = NAudio.Wave.WaveFormat;
 
 namespace Captura.NAudio
 {
     // TODO: Make this work ;-(
+    // TODO: Implement changing audio device active state
     class MixedAudioProvider : IAudioProvider
     {
-        readonly IEnumerable<NAudioProvider> _audioProviders;
+        readonly Dictionary<NAudioProvider, ISampleProvider> _audioProviders = new Dictionary<NAudioProvider, ISampleProvider>();
 
         public MixedAudioProvider(IEnumerable<NAudioProvider> AudioProviders)
         {
-            _audioProviders = AudioProviders;
+            foreach (var provider in AudioProviders)
+            {
+                var bufferedProvider = new BufferedWaveProvider(Wf.CreateIeeeFloatWaveFormat(44100, 2));
+
+                provider.DataAvailable += (S, E) =>
+                {
+                    bufferedProvider.AddSamples(E.Buffer, 0, E.Length);
+                };
+
+                var sampleProvider = bufferedProvider.ToSampleProvider();
+
+                _audioProviders.Add(provider, sampleProvider);
+            }
         }
 
         public void Dispose()
         {
-            foreach (var provider in _audioProviders)
+            foreach (var provider in _audioProviders.Keys)
             {
                 provider.Dispose();
             }
@@ -26,7 +42,7 @@ namespace Captura.NAudio
 
         public void Start()
         {
-            foreach (var provider in _audioProviders)
+            foreach (var provider in _audioProviders.Keys)
             {
                 provider.Start();
             }
@@ -34,7 +50,7 @@ namespace Captura.NAudio
 
         public void Stop()
         {
-            foreach (var provider in _audioProviders)
+            foreach (var provider in _audioProviders.Keys)
             {
                 provider.Stop();
             }

--- a/src/Captura.NAudio/MixedAudioProvider.cs
+++ b/src/Captura.NAudio/MixedAudioProvider.cs
@@ -10,7 +10,6 @@ using Wf = NAudio.Wave.WaveFormat;
 
 namespace Captura.NAudio
 {
-    // TODO: Implement changing audio device active state
     class MixedAudioProvider : IAudioProvider
     {
         readonly Dictionary<NAudioProvider, ISampleProvider> _audioProviders = new Dictionary<NAudioProvider, ISampleProvider>();

--- a/src/Captura.NAudio/NAudioItem.cs
+++ b/src/Captura.NAudio/NAudioItem.cs
@@ -1,0 +1,34 @@
+﻿using Captura.Models;
+using NAudio.CoreAudioApi;
+
+namespace Captura.NAudio
+{
+    class NAudioItem : NotifyPropertyChanged, IAudioItem
+    {
+        public MMDevice Device { get; }
+
+        public string Name { get; }
+
+        public NAudioItem(MMDevice Device)
+        {
+            this.Device = Device;
+
+            Name = Device.FriendlyName;
+        }
+
+        bool _active;
+
+        public bool Active
+        {
+            get => _active;
+            set
+            {
+                _active = value;
+
+                OnPropertyChanged();
+            }
+        }
+
+        public override string ToString() => Name;
+    }
+}

--- a/src/Captura.NAudio/NAudioProvider.cs
+++ b/src/Captura.NAudio/NAudioProvider.cs
@@ -19,19 +19,19 @@ namespace Captura.NAudio
             };
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             _waveIn.Dispose();
         }
 
         public WaveFormat WaveFormat { get; }
 
-        public void Start()
+        public virtual void Start()
         {
             _waveIn.StartRecording();
         }
 
-        public void Stop()
+        public virtual void Stop()
         {
             _waveIn.StopRecording();
         }

--- a/src/Captura.NAudio/NAudioProvider.cs
+++ b/src/Captura.NAudio/NAudioProvider.cs
@@ -5,7 +5,7 @@ using WaveFormat = Captura.Audio.WaveFormat;
 
 namespace Captura.NAudio
 {
-    public abstract class NAudioProvider : IAudioProvider
+    abstract class NAudioProvider : IAudioProvider
     {
         readonly IWaveIn _waveIn;
 
@@ -24,7 +24,7 @@ namespace Captura.NAudio
             _waveIn.Dispose();
         }
 
-        public WaveFormat WaveFormat { get; }
+        public WaveFormat WaveFormat { get; } = WaveFormat.CreateIeeeFloatWaveFormat(44100, 2);
 
         public virtual void Start()
         {

--- a/src/Captura.NAudio/NAudioProvider.cs
+++ b/src/Captura.NAudio/NAudioProvider.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Captura.Audio;
+using NAudio.Wave;
+using WaveFormat = Captura.Audio.WaveFormat;
+
+namespace Captura.NAudio
+{
+    public abstract class NAudioProvider : IAudioProvider
+    {
+        readonly IWaveIn _waveIn;
+
+        protected NAudioProvider(IWaveIn WaveIn)
+        {
+            _waveIn = WaveIn;
+
+            _waveIn.DataAvailable += (S, E) =>
+            {
+                DataAvailable?.Invoke(this, new DataAvailableEventArgs(E.Buffer, E.BytesRecorded));
+            };
+        }
+
+        public void Dispose()
+        {
+            _waveIn.Dispose();
+        }
+
+        public WaveFormat WaveFormat { get; }
+
+        public void Start()
+        {
+            _waveIn.StartRecording();
+        }
+
+        public void Stop()
+        {
+            _waveIn.StopRecording();
+        }
+
+        public event EventHandler<DataAvailableEventArgs> DataAvailable;
+    }
+}

--- a/src/Captura.NAudio/NAudioSource.cs
+++ b/src/Captura.NAudio/NAudioSource.cs
@@ -5,6 +5,7 @@ using NAudio.CoreAudioApi;
 
 namespace Captura.NAudio
 {
+    // ReSharper disable once ClassNeverInstantiated.Global
     public class NAudioSource : AudioSource
     {
         public NAudioSource()

--- a/src/Captura.NAudio/NAudioSource.cs
+++ b/src/Captura.NAudio/NAudioSource.cs
@@ -61,5 +61,7 @@ namespace Captura.NAudio
 
             return rec.Concat(loop).ToArray();
         }
+
+        public override string Name { get; } = "NAudio";
     }
 }

--- a/src/Captura.NAudio/NAudioSource.cs
+++ b/src/Captura.NAudio/NAudioSource.cs
@@ -1,0 +1,43 @@
+﻿using Captura.Audio;
+using Captura.Models;
+using NAudio.CoreAudioApi;
+
+namespace Captura.NAudio
+{
+    public class NAudioSource : AudioSource
+    {
+        public NAudioSource()
+        {
+            Refresh();
+        }
+
+        protected override void OnRefresh()
+        {
+            var enumerator = new MMDeviceEnumerator();
+
+            var loopbackDevs = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+
+            foreach (var loopback in loopbackDevs)
+            {
+                LoopbackSources.Add(new NAudioItem(loopback));
+            }
+
+            var recordingDevs = enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
+
+            foreach (var recording in recordingDevs)
+            {
+                RecordingSources.Add(new NAudioItem(recording));
+            }
+        }
+
+        public override IAudioProvider GetMixedAudioProvider()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override IAudioProvider[] GetMultipleAudioProviders()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/Captura.NAudio/NAudioSource.cs
+++ b/src/Captura.NAudio/NAudioSource.cs
@@ -6,6 +6,14 @@ using NAudio.CoreAudioApi;
 namespace Captura.NAudio
 {
     // ReSharper disable once ClassNeverInstantiated.Global
+    /// <summary>
+    /// Fallback to NAudio when BASS is not available.
+    /// </summary>
+    /// <remarks>
+    /// The audio device must support WASAPI Shared mode in 32-bit floating-point, 44100 Hz, Stereo.
+    /// Recording to separate audio files is working.
+    /// Audio mixing works but changing sources during recording is not supported.
+    /// </remarks>
     public class NAudioSource : AudioSource
     {
         public NAudioSource()

--- a/src/Captura.NAudio/NAudioSource.cs
+++ b/src/Captura.NAudio/NAudioSource.cs
@@ -1,4 +1,5 @@
-﻿using Captura.Audio;
+﻿using System.Linq;
+using Captura.Audio;
 using Captura.Models;
 using NAudio.CoreAudioApi;
 
@@ -37,7 +38,17 @@ namespace Captura.NAudio
 
         public override IAudioProvider[] GetMultipleAudioProviders()
         {
-            throw new System.NotImplementedException();
+            var rec = AvailableRecordingSources.Where(M => M.Active)
+                .Cast<NAudioItem>()
+                .Select(M => new WasapiCaptureProvider(M.Device))
+                .Cast<IAudioProvider>();
+
+            var loop = AvailableLoopbackSources.Where(M => M.Active)
+                .Cast<NAudioItem>()
+                .Select(M => new WasapiLoopbackCaptureProvider(M.Device))
+                .Cast<IAudioProvider>();
+
+            return rec.Concat(loop).ToArray();
         }
     }
 }

--- a/src/Captura.NAudio/NAudioSource.cs
+++ b/src/Captura.NAudio/NAudioSource.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Captura.Audio;
 using Captura.Models;
 using NAudio.CoreAudioApi;
@@ -34,7 +35,7 @@ namespace Captura.NAudio
 
         public override IAudioProvider GetMixedAudioProvider()
         {
-            throw new System.NotImplementedException();
+            throw new NotImplementedException();
         }
 
         public override IAudioProvider[] GetMultipleAudioProviders()

--- a/src/Captura.NAudio/NAudioSource.cs
+++ b/src/Captura.NAudio/NAudioSource.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Captura.Audio;
 using Captura.Models;
 using NAudio.CoreAudioApi;
@@ -35,7 +34,17 @@ namespace Captura.NAudio
 
         public override IAudioProvider GetMixedAudioProvider()
         {
-            throw new NotImplementedException();
+            var rec = AvailableRecordingSources.Where(M => M.Active)
+                .Cast<NAudioItem>()
+                .Select(M => new WasapiCaptureProvider(M.Device))
+                .Cast<NAudioProvider>();
+
+            var loop = AvailableLoopbackSources.Where(M => M.Active)
+                .Cast<NAudioItem>()
+                .Select(M => new WasapiLoopbackCaptureProvider(M.Device))
+                .Cast<NAudioProvider>();
+
+            return new MixedAudioProvider(rec.Concat(loop));
         }
 
         public override IAudioProvider[] GetMultipleAudioProviders()

--- a/src/Captura.NAudio/WasapiCaptureProvider.cs
+++ b/src/Captura.NAudio/WasapiCaptureProvider.cs
@@ -1,0 +1,10 @@
+﻿using NAudio.CoreAudioApi;
+
+namespace Captura.NAudio
+{
+    public class WasapiCaptureProvider : NAudioProvider
+    {
+        public WasapiCaptureProvider(MMDevice Device)
+            : base(new WasapiCapture(Device)) { }
+    }
+}

--- a/src/Captura.NAudio/WasapiCaptureProvider.cs
+++ b/src/Captura.NAudio/WasapiCaptureProvider.cs
@@ -2,7 +2,7 @@
 
 namespace Captura.NAudio
 {
-    public class WasapiCaptureProvider : NAudioProvider
+    class WasapiCaptureProvider : NAudioProvider
     {
         public WasapiCaptureProvider(MMDevice Device)
             : base(new WasapiCapture(Device)) { }

--- a/src/Captura.NAudio/WasapiLoopbackCaptureProvider.cs
+++ b/src/Captura.NAudio/WasapiLoopbackCaptureProvider.cs
@@ -1,0 +1,11 @@
+﻿using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace Captura.NAudio
+{
+    public class WasapiLoopbackCaptureProvider : NAudioProvider
+    {
+        public WasapiLoopbackCaptureProvider(MMDevice Device)
+            : base(new WasapiLoopbackCapture(Device)) { }
+    }
+}

--- a/src/Captura.NAudio/WasapiLoopbackCaptureProvider.cs
+++ b/src/Captura.NAudio/WasapiLoopbackCaptureProvider.cs
@@ -4,7 +4,7 @@ using Wf = NAudio.Wave.WaveFormat;
 
 namespace Captura.NAudio
 {
-    public class WasapiLoopbackCaptureProvider : NAudioProvider
+    class WasapiLoopbackCaptureProvider : NAudioProvider
     {
         readonly IWavePlayer _wasapiOut;
 

--- a/src/Captura.NAudio/WasapiLoopbackCaptureProvider.cs
+++ b/src/Captura.NAudio/WasapiLoopbackCaptureProvider.cs
@@ -1,11 +1,40 @@
 ﻿using NAudio.CoreAudioApi;
 using NAudio.Wave;
+using Wf = NAudio.Wave.WaveFormat;
 
 namespace Captura.NAudio
 {
     public class WasapiLoopbackCaptureProvider : NAudioProvider
     {
+        readonly IWavePlayer _wasapiOut;
+
         public WasapiLoopbackCaptureProvider(MMDevice Device)
-            : base(new WasapiLoopbackCapture(Device)) { }
+            : base(new WasapiLoopbackCapture(Device))
+        {
+            _wasapiOut = new WasapiOut(Device, AudioClientShareMode.Shared, true, 200);
+
+            _wasapiOut.Init(new SilenceProvider(Wf.CreateIeeeFloatWaveFormat(44100, 2)));
+        }
+
+        public override void Start()
+        {
+            _wasapiOut.Play();
+
+            base.Start();
+        }
+
+        public override void Stop()
+        {
+            base.Stop();
+
+            _wasapiOut.Stop();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            _wasapiOut.Dispose();
+        }
     }
 }

--- a/src/Captura.sln
+++ b/src/Captura.sln
@@ -38,6 +38,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Captura.Hotkeys", "Captura.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Captura.Fakes", "Captura.Fakes\Captura.Fakes.csproj", "{0BB58B16-1A6C-4256-AEC2-3EA64541B663}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Captura.NAudio", "Captura.NAudio\Captura.NAudio.csproj", "{76BC6324-E205-41DB-B60A-128D9FD66624}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -108,6 +110,10 @@ Global
 		{0BB58B16-1A6C-4256-AEC2-3EA64541B663}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BB58B16-1A6C-4256-AEC2-3EA64541B663}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0BB58B16-1A6C-4256-AEC2-3EA64541B663}.Release|Any CPU.Build.0 = Release|Any CPU
+		{76BC6324-E205-41DB-B60A-128D9FD66624}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{76BC6324-E205-41DB-B60A-128D9FD66624}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{76BC6324-E205-41DB-B60A-128D9FD66624}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76BC6324-E205-41DB-B60A-128D9FD66624}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Captura/Pages/AudioPage.xaml
+++ b/src/Captura/Pages/AudioPage.xaml
@@ -81,11 +81,6 @@
 
             <StackPanel IsEnabled="{Binding RecordingViewModel.RecorderState, Converter={StaticResource NotRecordingConverter}}"
                         Margin="0,20,0,0">
-                <CheckBox IsChecked="{Binding Settings.Audio.PlaybackRecordingRealTime}"
-                          Content="{Binding PlayRecAudio, Source={StaticResource Loc}, Mode=OneWay}"
-                          IsEnabled="{Binding Settings.Audio.SeparateFilePerSource, Converter={StaticResource NegatingConverter}}"
-                          Margin="0,5"/>
-
                 <CheckBox IsChecked="{Binding Settings.Audio.SeparateFilePerSource}"
                           Content="{Binding SeparateAudioFiles, Source={StaticResource Loc}, Mode=OneWay}"
                           Margin="0,5"/>

--- a/src/Captura/Pages/AudioPage.xaml
+++ b/src/Captura/Pages/AudioPage.xaml
@@ -5,12 +5,19 @@
     <Grid>
         <StackPanel DataContext="{Binding MainViewModel, Source={StaticResource ServiceLocator}}"
                     Margin="5,0,0,0">
-            <CheckBox Content="{Binding Audio, Source={StaticResource Loc}, Mode=OneWay}"
-                      IsChecked="{Binding Settings.Audio.Enabled, Mode=TwoWay}"
-                      IsEnabled="{Binding RecordingViewModel.RecorderState, Converter={StaticResource NotRecordingConverter}}"
-                      FontWeight="Bold"
-                      Margin="0,0,0,5"
-                      FontSize="15"/>
+            <DockPanel Margin="0,0,0,5">
+                <TextBlock Text="{Binding AudioSource.Name}"
+                           FontSize="10"
+                           DockPanel.Dock="Right"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource Accent}"/>
+
+                <CheckBox Content="{Binding Audio, Source={StaticResource Loc}, Mode=OneWay}"
+                          IsChecked="{Binding Settings.Audio.Enabled, Mode=TwoWay}"
+                          IsEnabled="{Binding RecordingViewModel.RecorderState, Converter={StaticResource NotRecordingConverter}}"
+                          FontWeight="Bold"
+                          FontSize="15"/>
+            </DockPanel>
 
             <ScrollViewer IsEnabled="{Binding Settings.Audio.Enabled}"
                           MaxHeight="130">


### PR DESCRIPTION
Fallback to NAudio when BASS is not available.
For testing, delete `bass.dll` or `bassmix.dll`.
Error message if BASS not present has been removed.
The currently used audio library is displayed in the UI.

The audio device must support WASAPI Shared mode in 32-bit floating-point, 44100 Hz, Stereo.

Recording to separate audio files is working.
Audio mixing works but changing sources during recording is not supported.

Removed `Playback recorded audio in real-time` option.

Requested in #323.