### PR TITLE
Support %CAPTURA_PATH%

### DIFF
--- a/src/Captura.Base/Services/ServiceProvider.cs
+++ b/src/Captura.Base/Services/ServiceProvider.cs
@@ -12,6 +12,8 @@ namespace Captura
 {
     public static class ServiceProvider
     {
+        public const string CapturaPathConstant = "%CAPTURA_PATH%";
+
         static string _settingsDir;
 
         public static string SettingsDir
@@ -19,7 +21,7 @@ namespace Captura
             get
             {
                 if (_settingsDir == null)
-                    _settingsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Captura");
+                    _settingsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), nameof(Captura));
 
                 if (!Directory.Exists(_settingsDir))
                     Directory.CreateDirectory(_settingsDir);
@@ -28,6 +30,11 @@ namespace Captura
             }
             set
             {
+                if (string.IsNullOrWhiteSpace(value))
+                    return;
+
+                value = value.Replace(CapturaPathConstant, AppDir);
+
                 _settingsDir = value;
 
                 if (!Directory.Exists(_settingsDir))

--- a/src/Captura.Console/Program.cs
+++ b/src/Captura.Console/Program.cs
@@ -88,13 +88,13 @@ namespace Captura
                     return;
                 }
 
-                var ffMpegDownload = ServiceProvider.Get<FFmpegDownloadViewModel>();
+                var ffmpegDownload = ServiceProvider.Get<FFmpegDownloadViewModel>();
 
-                ffMpegDownload.TargetFolder = FFmpegOptions.Install;
+                ServiceProvider.Get<FFmpegSettings>().FolderPath = downloadFolder;
 
-                await ffMpegDownload.Start();
+                await ffmpegDownload.Start();
                 
-                WriteLine(ffMpegDownload.Status);
+                WriteLine(ffmpegDownload.Status);
             }
         }
     }

--- a/src/Captura.Core/Settings/Settings.cs
+++ b/src/Captura.Core/Settings/Settings.cs
@@ -144,11 +144,9 @@ namespace Captura
         {
             var path = OutPath;
 
-            const string capturaPathConstant = "%CAPTURA_PATH%";
-
             if (!string.IsNullOrWhiteSpace(path))
             {
-                path = path.Replace(capturaPathConstant, ServiceProvider.AppDir);
+                path = path.Replace(ServiceProvider.CapturaPathConstant, ServiceProvider.AppDir);
             }
 
             return path;

--- a/src/Captura.Core/Settings/Settings.cs
+++ b/src/Captura.Core/Settings/Settings.cs
@@ -71,8 +71,10 @@ namespace Captura
 
         public void EnsureOutPath()
         {
-            if (!Directory.Exists(OutPath))
-                Directory.CreateDirectory(OutPath);
+            var outPath = GetOutputPath();
+
+            if (!Directory.Exists(outPath))
+                Directory.CreateDirectory(outPath);
         }
 
         public ProxySettings Proxy { get; } = new ProxySettings();
@@ -138,6 +140,20 @@ namespace Captura
             set => Set(value);
         }
 
+        public string GetOutputPath()
+        {
+            var path = OutPath;
+
+            const string capturaPathConstant = "%CAPTURA_PATH%";
+
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                path = path.Replace(capturaPathConstant, ServiceProvider.AppDir);
+            }
+
+            return path;
+        }
+
         public string FilenameFormat
         {
             get => Get("%yyyy%-%MM%-%dd%-%HH%-%mm%-%ss%");
@@ -152,8 +168,10 @@ namespace Captura
             if (!Extension.StartsWith("."))
                 Extension = $".{Extension}";
 
+            var outPath = GetOutputPath();
+
             if (string.IsNullOrWhiteSpace(FilenameFormat))
-                return Path.Combine(OutPath, $"{DateTime.Now:yyyy-MM-dd-HH-mm-ss}{Extension}");
+                return Path.Combine(outPath, $"{DateTime.Now:yyyy-MM-dd-HH-mm-ss}{Extension}");
 
             var now = DateTime.Now;
 
@@ -177,7 +195,7 @@ namespace Captura
                 .Replace("%tt%", now.ToString("tt"))
                 .Replace("%zzz%", now.ToString("zzz"));
             
-            var path = Path.Combine(OutPath, $"{filename}{Extension}");
+            var path = Path.Combine(outPath, $"{filename}{Extension}");
 
             if (!File.Exists(path))
                 return path;
@@ -186,7 +204,7 @@ namespace Captura
 
             do
             {
-                path = Path.Combine(OutPath, $"{filename} ({i++}){Extension}");
+                path = Path.Combine(outPath, $"{filename} ({i++}){Extension}");
             }
             while (File.Exists(path));
 

--- a/src/Captura.Core/ViewModels/MainModel.cs
+++ b/src/Captura.Core/ViewModels/MainModel.cs
@@ -19,7 +19,6 @@ namespace Captura.ViewModels
         readonly HotKeyManager _hotKeyManager;
 
         public MainModel(Settings Settings,
-            IWebCamProvider WebCamProvider,
             VideoWritersViewModel VideoWritersViewModel,
             AudioSource AudioSource,
             HotKeyManager HotKeyManager,
@@ -34,8 +33,8 @@ namespace Captura.ViewModels
             _webcamModel = WebcamModel;
 
             // If Output Dircetory is not set. Set it to Documents\Captura\
-            if (string.IsNullOrWhiteSpace(Settings.OutPath))
-                Settings.OutPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Captura");
+            if (string.IsNullOrWhiteSpace(Settings.GetOutputPath()))
+                Settings.OutPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), nameof(Captura));
 
             // Create the Output Directory if it does not exist
             Settings.EnsureOutPath();

--- a/src/Captura.FFmpeg/FFmpegService.cs
+++ b/src/Captura.FFmpeg/FFmpegService.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
-using System.Reflection;
 
 namespace Captura
 {
@@ -18,12 +17,12 @@ namespace Captura
         {
             get
             {
-                var settings = GetSettings();
+                var folderPath = GetSettings().GetFolderPath();
 
                 // FFmpeg folder
-                if (!string.IsNullOrWhiteSpace(settings.FolderPath))
+                if (!string.IsNullOrWhiteSpace(folderPath))
                 {
-                    var path = Path.Combine(settings.FolderPath, FFmpegExeName);
+                    var path = Path.Combine(folderPath, FFmpegExeName);
 
                     if (File.Exists(path))
                         return true;
@@ -53,12 +52,12 @@ namespace Captura
         {
             get
             {
-                var settings = GetSettings();
+                var folderPath = GetSettings().GetFolderPath();
 
                 // FFmpeg folder
-                if (!string.IsNullOrWhiteSpace(settings.FolderPath))
+                if (!string.IsNullOrWhiteSpace(folderPath))
                 {
-                    var path = Path.Combine(settings.FolderPath, FFmpegExeName);
+                    var path = Path.Combine(folderPath, FFmpegExeName);
 
                     if (File.Exists(path))
                         return path;
@@ -77,7 +76,7 @@ namespace Captura
 
             var dialogService = ServiceProvider.Get<IDialogService>();
 
-            var folder = dialogService.PickFolder(settings.FolderPath, LanguageManager.Instance.SelectFFmpegFolder);
+            var folder = dialogService.PickFolder(settings.GetFolderPath(), LanguageManager.Instance.SelectFFmpegFolder);
             
             if (!string.IsNullOrWhiteSpace(folder))
                 settings.FolderPath = folder;

--- a/src/Captura.FFmpeg/FFmpgDownloadViewModel.cs
+++ b/src/Captura.FFmpeg/FFmpgDownloadViewModel.cs
@@ -35,47 +35,44 @@ namespace Captura.ViewModels
 
         readonly IDialogService _dialogService;
         readonly ProxySettings _proxySettings;
-        readonly FFmpegSettings _ffmpegSettings;
+        public FFmpegSettings FFmpegSettings { get; }
         readonly LanguageManager _loc;
 
-        public FFmpegDownloadViewModel(IDialogService DialogService, ProxySettings ProxySettings, LanguageManager Loc, FFmpegSettings FFmpegSettings)
+        public FFmpegDownloadViewModel(IDialogService DialogService,
+            ProxySettings ProxySettings,
+            LanguageManager Loc,
+            FFmpegSettings FFmpegSettings)
         {
             _dialogService = DialogService;
             _proxySettings = ProxySettings;
             _loc = Loc;
-            _ffmpegSettings = FFmpegSettings;
+
+            this.FFmpegSettings = FFmpegSettings;
 
             StartCommand = new DelegateCommand(OnStartExecute);
-
-            SetDefaultTargetFolderToLocalAppData();
 
             SelectFolderCommand = new DelegateCommand(OnSelectFolderExecute);
 
             OpenFolderCommand = new DelegateCommand(() =>
             {
-                if (Directory.Exists(_targetFolder))
+                var path = FFmpegSettings.GetFolderPath();
+
+                if (Directory.Exists(path))
                 {
-                    Process.Start(_targetFolder);
+                    Process.Start(path);
                 }
             });
+
+            EnsureDir();
         }
 
-        void SetDefaultTargetFolderToLocalAppData()
+        void EnsureDir()
         {
-            if (!string.IsNullOrWhiteSpace(_ffmpegSettings.FolderPath))
-            {
-                _targetFolder = _ffmpegSettings.GetFolderPath();
-            }
-            else
-            {
-                var localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var path = FFmpegSettings.GetFolderPath();
 
-                _targetFolder = Path.Combine(localAppDataPath, nameof(Captura));
-            }
-
-            if (!Directory.Exists(_targetFolder))
+            if (!Directory.Exists(path))
             {
-                Directory.CreateDirectory(_targetFolder);
+                Directory.CreateDirectory(path);
             }
         }
 
@@ -97,10 +94,10 @@ namespace Captura.ViewModels
 
         void OnSelectFolderExecute()
         {
-            var folder = _dialogService.PickFolder(TargetFolder, _loc.SelectFFmpegFolder);
+            var folder = _dialogService.PickFolder(FFmpegSettings.GetFolderPath(), _loc.SelectFFmpegFolder);
 
             if (!string.IsNullOrWhiteSpace(folder))
-                TargetFolder = folder;
+                FFmpegSettings.FolderPath = folder;
         }
 
         const string CancelDownload = "Cancel Download";
@@ -165,7 +162,7 @@ namespace Captura.ViewModels
 
             try
             {
-                await DownloadFFmpeg.ExtractTo(TargetFolder);
+                await DownloadFFmpeg.ExtractTo(FFmpegSettings.GetFolderPath());
             }
             catch (UnauthorizedAccessException)
             {
@@ -177,9 +174,6 @@ namespace Captura.ViewModels
                 Status = "Extraction failed";
                 return false;
             }
-            
-            // Update FFmpeg folder setting
-            _ffmpegSettings.FolderPath = TargetFolder;
             
             Status = "Done";
             ActionDescription = Finish;
@@ -197,19 +191,6 @@ namespace Captura.ViewModels
             private set
             {
                 _actionDescription = value;
-
-                OnPropertyChanged();
-            }
-        }
-
-        string _targetFolder;
-
-        public string TargetFolder
-        {
-            get => _targetFolder;
-            set
-            {
-                _targetFolder = value;
 
                 OnPropertyChanged();
             }

--- a/src/Captura.FFmpeg/FFmpgDownloadViewModel.cs
+++ b/src/Captura.FFmpeg/FFmpgDownloadViewModel.cs
@@ -64,13 +64,13 @@ namespace Captura.ViewModels
         {
             if (!string.IsNullOrWhiteSpace(_ffmpegSettings.FolderPath))
             {
-                _targetFolder = _ffmpegSettings.FolderPath;
+                _targetFolder = _ffmpegSettings.GetFolderPath();
             }
             else
             {
                 var localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-                _targetFolder = Path.Combine(localAppDataPath, "Captura");
+                _targetFolder = Path.Combine(localAppDataPath, nameof(Captura));
             }
 
             if (!Directory.Exists(_targetFolder))

--- a/src/Captura.FFmpeg/Settings/FFMpegSettings.cs
+++ b/src/Captura.FFmpeg/Settings/FFMpegSettings.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
+using System.IO;
 
 namespace Captura
 {
@@ -17,6 +19,12 @@ namespace Captura
             if (!string.IsNullOrWhiteSpace(path))
             {
                 path = path.Replace(ServiceProvider.CapturaPathConstant, ServiceProvider.AppDir);
+            }
+            else
+            {
+                var localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+                path = Path.Combine(localAppDataPath, nameof(Captura));
             }
 
             return path;

--- a/src/Captura.FFmpeg/Settings/FFMpegSettings.cs
+++ b/src/Captura.FFmpeg/Settings/FFMpegSettings.cs
@@ -10,6 +10,18 @@ namespace Captura
             set => Set(value);
         }
 
+        public string GetFolderPath()
+        {
+            var path = FolderPath;
+
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                path = path.Replace(ServiceProvider.CapturaPathConstant, ServiceProvider.AppDir);
+            }
+
+            return path;
+        }
+
         public string TwitchKey
         {
             get => Get("");

--- a/src/Captura.ViewCore/ViewModels/MainViewModel.cs
+++ b/src/Captura.ViewCore/ViewModels/MainViewModel.cs
@@ -74,12 +74,12 @@ namespace Captura.ViewModels
         {
             Settings.EnsureOutPath();
 
-            Process.Start(Settings.OutPath);
+            Process.Start(Settings.GetOutputPath());
         }
 
         void SelectOutputFolder()
         {
-            var folder = _dialogService.PickFolder(Settings.OutPath, Loc.SelectOutFolder);
+            var folder = _dialogService.PickFolder(Settings.GetOutputPath(), Loc.SelectOutFolder);
 
             if (folder != null)
                 Settings.OutPath = folder;

--- a/src/Captura/Properties/AssemblyInfo.cs
+++ b/src/Captura/Properties/AssemblyInfo.cs
@@ -1,9 +1,9 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyTitle("Captura")]
+[assembly: AssemblyTitle(nameof(Captura))]
 [assembly: AssemblyDescription("Captures Screen/Window as ScreenShot/ScreenCast along with Audio from Microphone/Loopback, Mouse Cursor, Clicks and Keystrokes")]
 [assembly: AssemblyCompany("Mathew Sachin")]
-[assembly: AssemblyProduct("Captura")]
+[assembly: AssemblyProduct(nameof(Captura))]
 [assembly: AssemblyCopyright("(c) 2018 Mathew Sachin")]
-[assembly: AssemblyTrademark("Captura")]
+[assembly: AssemblyTrademark(nameof(Captura))]
 [assembly: AssemblyVersion("0.0.0")]

--- a/src/Captura/Windows/FFmpegDownloaderWindow.xaml
+++ b/src/Captura/Windows/FFmpegDownloaderWindow.xaml
@@ -76,11 +76,11 @@
                       Width="16"
                       Data="{Binding Icons.More, Source={StaticResource ServiceLocator}}"/>
             </Button>
-            <Border ToolTip="{Binding TargetFolder, Mode=OneWay}"
+            <Border ToolTip="{Binding FFmpegSettings.FolderPath, Mode=OneWay}"
                     MouseUp="SelectTargetFolder">
                 <TextBox IsReadOnly="True"
                          IsEnabled="False"
-                         Text="{Binding TargetFolder, Mode=OneWay}"/>
+                         Text="{Binding FFmpegSettings.FolderPath, Mode=OneWay}"/>
             </Border>
         </DockPanel>
         

--- a/src/Tests/Fixtures/AppRunnerFixture.cs
+++ b/src/Tests/Fixtures/AppRunnerFixture.cs
@@ -15,7 +15,7 @@ namespace Captura.Tests.Views
         {
             App = Application.Launch(new ProcessStartInfo(TestManagerFixture.GetUiPath(), "--no-persist"));
 
-            MainWindow = App.GetWindow("Captura");
+            MainWindow = App.GetWindow(nameof(Captura));
         }
 
         public void Dispose()

--- a/src/Tests/Fixtures/TestManagerFixture.cs
+++ b/src/Tests/Fixtures/TestManagerFixture.cs
@@ -39,7 +39,7 @@ namespace Captura.Tests
 
         public static string GetUiPath()
         {
-            return GetPath("Captura", "captura.exe");
+            return GetPath(nameof(Captura), "captura.exe");
         }
     }
 }


### PR DESCRIPTION
`%CAPTURA_PATH%` will be recognized as app directory for the following:

- [x] `--settings` command-line argument
- [x] Output folder path
- [x] FFmpeg folder path