### PR TITLE
Font setting for Overlays

### DIFF
--- a/src/Captura.Base/Images/IEditableFrame.cs
+++ b/src/Captura.Base/Images/IEditableFrame.cs
@@ -21,9 +21,11 @@ namespace Captura
 
         void DrawEllipse(Color Color, float StrokeWidth, RectangleF Rectangle);
 
-        SizeF MeasureString(string Text, int FontSize);
+        IFont GetFont(string FontFamily, int Size);
 
-        void DrawString(string Text, int FontSize, Color Color, RectangleF LayoutRectangle);
+        SizeF MeasureString(string Text, IFont Font);
+
+        void DrawString(string Text, IFont Font, Color Color, RectangleF LayoutRectangle);
 
         IBitmapFrame GenerateFrame();
     }

--- a/src/Captura.Base/Images/IFont.cs
+++ b/src/Captura.Base/Images/IFont.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Captura
+{
+    public interface IFont : IDisposable
+    {
+        int Size { get; }
+
+        string FontFamily { get; }
+    }
+}

--- a/src/Captura.Base/Images/IFont.cs
+++ b/src/Captura.Base/Images/IFont.cs
@@ -4,6 +4,9 @@ namespace Captura
 {
     public interface IFont : IDisposable
     {
+        /// <summary>
+        /// Font Size in Device Independent Pixels
+        /// </summary>
         int Size { get; }
 
         string FontFamily { get; }

--- a/src/Captura.Base/Images/RepeatFrame.cs
+++ b/src/Captura.Base/Images/RepeatFrame.cs
@@ -66,12 +66,17 @@ namespace Captura
             throw new NotImplementedException();
         }
 
-        SizeF IEditableFrame.MeasureString(string Text, int FontSize)
+        IFont IEditableFrame.GetFont(string FontFamily, int Size)
         {
             throw new NotImplementedException();
         }
 
-        void IEditableFrame.DrawString(string Text, int FontSize, Color Color, RectangleF LayoutRectangle)
+        SizeF IEditableFrame.MeasureString(string Text, IFont Font)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IEditableFrame.DrawString(string Text, IFont Font, Color Color, RectangleF LayoutRectangle)
         {
             throw new NotImplementedException();
         }

--- a/src/Captura.Base/Settings/TextOverlaySettings.cs
+++ b/src/Captura.Base/Settings/TextOverlaySettings.cs
@@ -11,6 +11,12 @@ namespace Captura
             set => Set(value);
         }
 
+        public string FontFamily
+        {
+            get => Get("Arial");
+            set => Set(value);
+        }
+
         public int FontSize
         {
             get => Get(20);

--- a/src/Captura.MouseKeyHook/MouseKeyHook.cs
+++ b/src/Captura.MouseKeyHook/MouseKeyHook.cs
@@ -248,14 +248,17 @@ namespace Captura.Models
 
                 if ((DateTime.Now - keyRecord.TimeStamp).TotalSeconds > _records.Size * _keystrokesSettings.Timeout)
                     continue;
-                
-                DrawKeys(_keystrokesSettings, Editor, keyRecord.Display, Math.Max(1, fontSize), opacity, offsetY);
 
-                var height = Editor.MeasureString("A", fontSize).Height;
+                using (var font = Editor.GetFont(_keystrokesSettings.FontFamily, Math.Max(1, fontSize)))
+                {
+                    DrawKeys(_keystrokesSettings, Editor, keyRecord.Display, font, opacity, offsetY);
 
-                offsetY += height + _keystrokesSettings.HistorySpacing;
+                    var height = Editor.MeasureString("A", font).Height;
 
-                offsetY += _keystrokesSettings.VerticalPadding * 2 + _keystrokesSettings.BorderThickness * 2;
+                    offsetY += height + _keystrokesSettings.HistorySpacing;
+
+                    offsetY += _keystrokesSettings.VerticalPadding * 2 + _keystrokesSettings.BorderThickness * 2;
+                }
 
                 if (index == 1)
                 {
@@ -265,9 +268,9 @@ namespace Captura.Models
             }
         }
 
-        static void DrawKeys(KeystrokesSettings KeystrokesSettings, IEditableFrame Editor, string Text, int FontSize, byte Opacity, float OffsetY)
+        static void DrawKeys(KeystrokesSettings KeystrokesSettings, IEditableFrame Editor, string Text, IFont Font, byte Opacity, float OffsetY)
         {
-            var size = Editor.MeasureString(Text, FontSize);
+            var size = Editor.MeasureString(Text, Font);
 
             int paddingX = KeystrokesSettings.HorizontalPadding, paddingY = KeystrokesSettings.VerticalPadding;
 
@@ -281,7 +284,7 @@ namespace Captura.Models
                 KeystrokesSettings.CornerRadius);
             
             Editor.DrawString(Text,
-                FontSize,
+                Font,
                 Color.FromArgb(Opacity, KeystrokesSettings.FontColor),
                 new RectangleF(rect.Left + paddingX, rect.Top + paddingY, size.Width, size.Height));
 

--- a/src/Captura.Windows/Imaging/DrawingFont.cs
+++ b/src/Captura.Windows/Imaging/DrawingFont.cs
@@ -10,13 +10,15 @@ namespace Screna
             this.FontFamily = FontFamily;
             this.Size = Size;
 
+            var emSize = Size * 72 / 96f;
+
             try
             {
-                Font = new Font(new FontFamily(FontFamily), Size);
+                Font = new Font(new FontFamily(FontFamily), emSize);
             }
             catch
             {
-                Font = new Font(System.Drawing.FontFamily.GenericMonospace, Size);
+                Font = new Font(System.Drawing.FontFamily.GenericMonospace, emSize);
             }
         }
 

--- a/src/Captura.Windows/Imaging/DrawingFont.cs
+++ b/src/Captura.Windows/Imaging/DrawingFont.cs
@@ -10,15 +10,13 @@ namespace Screna
             this.FontFamily = FontFamily;
             this.Size = Size;
 
-            var emSize = Size * 72 / 96f;
-
             try
             {
-                Font = new Font(new FontFamily(FontFamily), emSize);
+                Font = new Font(new FontFamily(FontFamily), Size, GraphicsUnit.Pixel);
             }
             catch
             {
-                Font = new Font(System.Drawing.FontFamily.GenericMonospace, emSize);
+                Font = new Font(System.Drawing.FontFamily.GenericMonospace, Size, GraphicsUnit.Pixel);
             }
         }
 

--- a/src/Captura.Windows/Imaging/DrawingFont.cs
+++ b/src/Captura.Windows/Imaging/DrawingFont.cs
@@ -1,0 +1,33 @@
+﻿using System.Drawing;
+using Captura;
+
+namespace Screna
+{
+    public class DrawingFont : IFont
+    {
+        public DrawingFont(string FontFamily, int Size)
+        {
+            this.FontFamily = FontFamily;
+            this.Size = Size;
+
+            try
+            {
+                Font = new Font(new FontFamily(FontFamily), Size);
+            }
+            catch
+            {
+                Font = new Font(System.Drawing.FontFamily.GenericMonospace, Size);
+            }
+        }
+
+        public Font Font { get; }
+
+        public void Dispose()
+        {
+            Font.Dispose();
+        }
+
+        public int Size { get; }
+        public string FontFamily { get; }
+    }
+}

--- a/src/Captura.Windows/Imaging/GraphicsEditor.cs
+++ b/src/Captura.Windows/Imaging/GraphicsEditor.cs
@@ -101,7 +101,7 @@ namespace Screna
         {
             if (Font is DrawingFont font)
             {
-                return _graphics.MeasureString(Text, font.Font);
+                return _graphics.MeasureString(Text, font.Font, PointF.Empty, StringFormat.GenericTypographic);
             }
 
             return SizeF.Empty;
@@ -111,7 +111,7 @@ namespace Screna
         {
             if (Font is DrawingFont font)
             {
-                _graphics.DrawString(Text, font.Font, new SolidBrush(Color), LayoutRectangle);
+                _graphics.DrawString(Text, font.Font, new SolidBrush(Color), LayoutRectangle, StringFormat.GenericTypographic);
             }
         }
 

--- a/src/Captura.Windows/Imaging/GraphicsEditor.cs
+++ b/src/Captura.Windows/Imaging/GraphicsEditor.cs
@@ -92,18 +92,27 @@ namespace Screna
             _graphics.DrawRoundedRectangle(new Pen(Color, StrokeWidth), Rectangle, CornerRadius);
         }
 
-        public SizeF MeasureString(string Text, int FontSize)
+        public IFont GetFont(string FontFamily, int Size)
         {
-            var font = new Font(FontFamily.GenericMonospace, FontSize);
-
-            return _graphics.MeasureString(Text, font);
+            return new DrawingFont(FontFamily, Size);
         }
 
-        public void DrawString(string Text, int FontSize, Color Color, RectangleF LayoutRectangle)
+        public SizeF MeasureString(string Text, IFont Font)
         {
-            var font = new Font(FontFamily.GenericMonospace, FontSize);
+            if (Font is DrawingFont font)
+            {
+                return _graphics.MeasureString(Text, font.Font);
+            }
 
-            _graphics.DrawString(Text, font, new SolidBrush(Color), LayoutRectangle);
+            return SizeF.Empty;
+        }
+
+        public void DrawString(string Text, IFont Font, Color Color, RectangleF LayoutRectangle)
+        {
+            if (Font is DrawingFont font)
+            {
+                _graphics.DrawString(Text, font.Font, new SolidBrush(Color), LayoutRectangle);
+            }
         }
 
         public float Width => _graphics.VisibleClipBounds.Width;

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -61,6 +61,9 @@
     <Compile Include="Controls\VideoSourceKindList.xaml.cs">
       <DependentUpon>VideoSourceKindList.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\FontSelector.xaml.cs">
+      <DependentUpon>FontSelector.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ImageEditor\DynamicRenderers\ArrowDynamicRenderer.cs" />
     <Compile Include="ImageEditor\DynamicRenderers\IDynamicRenderer.cs" />
     <Compile Include="ImageEditor\Strokes\ArrowStroke.cs" />
@@ -296,6 +299,9 @@
     </Page>
     <Page Include="Controls\ModernPasswordBox.xaml">
       <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\FontSelector.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Pages\CensorOverlaysPage.xaml">

--- a/src/Captura/Controls/FontSelector.xaml
+++ b/src/Captura/Controls/FontSelector.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl x:Class="Captura.FontSelector"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="30" d:DesignWidth="200"
+             Name="This">
+    <ComboBox ItemsSource="{Binding Source={x:Static Fonts.SystemFontFamilies}}"
+              SelectedValue="{Binding SelectedFont, ElementName=This, Mode=TwoWay}"
+              SelectedValuePath="Source"
+              ToolTip="{Binding SelectedFont, ElementName=This}"/>
+</UserControl>

--- a/src/Captura/Controls/FontSelector.xaml.cs
+++ b/src/Captura/Controls/FontSelector.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows;
+
+namespace Captura
+{
+    public partial class FontSelector
+    {
+        public FontSelector()
+        {
+            InitializeComponent();
+        }
+
+        public static readonly DependencyProperty SelectedFontProperty = DependencyProperty.Register(
+            nameof(SelectedFont),
+            typeof(string),
+            typeof(FontSelector),
+            new FrameworkPropertyMetadata("Arial"));
+
+        public string SelectedFont
+        {
+            get => (string) GetValue(SelectedFontProperty);
+            set => SetValue(SelectedFontProperty, value);
+        }
+    }
+}

--- a/src/Captura/Controls/TextOverlaySettingsControl.xaml
+++ b/src/Captura/Controls/TextOverlaySettingsControl.xaml
@@ -13,7 +13,8 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="70"/>
+                <ColumnDefinition Width="40"/>
             </Grid.ColumnDefinitions>
             
             <Path Data="{Binding Icons.Font, Source={StaticResource ServiceLocator}}"
@@ -24,14 +25,18 @@
                   VerticalAlignment="Center"
                   ToolTip="Font"/>
 
+            <local:FontSelector Grid.Column="1"
+                                Margin="10,5,5,5"
+                                SelectedFont="{Binding FontFamily, Mode=TwoWay}"/>
+
             <xctk:IntegerUpDown Minimum="1"
                                 Value="{Binding FontSize, Mode=TwoWay}"
-                                Grid.Column="1"
-                                Margin="10,5,5,5"
+                                Grid.Column="2"
+                                Margin="0,5"
                                 ToolTip="{Binding FontSize, Source={StaticResource Loc}, Mode=OneWay}"/>
 
             <xctk:ColorPicker SelectedColor="{Binding FontColor, Converter={StaticResource WpfColorConverter}, Mode=TwoWay}"
-                              Grid.Column="2"
+                              Grid.Column="3"
                               Margin="0,5"
                               ToolTip="{Binding Color, Source={StaticResource Loc}, Mode=OneWay}"/>
         </Grid>

--- a/src/Captura/Windows/OverlayWindow.xaml
+++ b/src/Captura/Windows/OverlayWindow.xaml
@@ -61,7 +61,7 @@
         
         <DockPanel Grid.Column="2">
             <Label DockPanel.Dock="Top"
-                   Content="Preview (Font Size - Not to Scale)"
+                   Content="{Binding Preview, Source={StaticResource Loc}}"
                    Padding="5"/>
 
             <Grid Background="Transparent"

--- a/src/Captura/Windows/OverlayWindow.xaml.cs
+++ b/src/Captura/Windows/OverlayWindow.xaml.cs
@@ -170,6 +170,7 @@ namespace Captura
         {
             var control = Generate(Settings, Text, ConvertColor(Settings.BackgroundColor));
             
+            control.Label.FontFamily = new FontFamily(Settings.FontFamily);
             control.Label.FontSize = Settings.FontSize;
 
             control.Border.Padding = new Thickness(Settings.HorizontalPadding,
@@ -201,6 +202,10 @@ namespace Captura
 
                     case nameof(Settings.BorderColor):
                         control.Border.BorderBrush = new SolidColorBrush(ConvertColor(Settings.BorderColor));
+                        break;
+
+                    case nameof(Settings.FontFamily):
+                        control.Label.FontFamily = new FontFamily(Settings.FontFamily);
                         break;
 
                     case nameof(Settings.FontSize):

--- a/src/DesktopDuplication/Direct2DEditor.cs
+++ b/src/DesktopDuplication/Direct2DEditor.cs
@@ -144,9 +144,9 @@ namespace DesktopDuplication
             _editorSession.RenderTarget.DrawEllipse(ToEllipse(Rectangle), Convert(Color), StrokeWidth);
         }
 
-        TextFormat GetTextFormat(int FontSize)
+        public IFont GetFont(string FontFamily, int Size)
         {
-            return new TextFormat(_editorSession.WriteFactory, "Arial", FontSize);
+            return new Direct2DFont(FontFamily, Size, _editorSession.WriteFactory);
         }
 
         TextLayout GetTextLayout(string Text, TextFormat Format)
@@ -154,24 +154,30 @@ namespace DesktopDuplication
             return new TextLayout(_editorSession.WriteFactory, Text, Format, Width, Height);
         }
 
-        public SizeF MeasureString(string Text, int FontSize)
+        public SizeF MeasureString(string Text, IFont Font)
         {
-            using (var format = GetTextFormat(FontSize))
-            using (var layout = GetTextLayout(Text, format))
+            if (Font is Direct2DFont font)
             {
-                return new SizeF(layout.Metrics.Width, layout.Metrics.Height);
+                using (var layout = GetTextLayout(Text, font.TextFormat))
+                {
+                    return new SizeF(layout.Metrics.Width, layout.Metrics.Height);
+                }
             }
+
+            return SizeF.Empty;
         }
 
-        public void DrawString(string Text, int FontSize, Color Color, RectangleF LayoutRectangle)
+        public void DrawString(string Text, IFont Font, Color Color, RectangleF LayoutRectangle)
         {
-            using (var format = GetTextFormat(FontSize))
-            using (var layout = GetTextLayout(Text, format))
+            if (Font is Direct2DFont font)
             {
-                _editorSession.RenderTarget.DrawTextLayout(
-                    new RawVector2(LayoutRectangle.X, LayoutRectangle.Y),
-                    layout,
-                    Convert(Color));
+                using (var layout = GetTextLayout(Text, font.TextFormat))
+                {
+                    _editorSession.RenderTarget.DrawTextLayout(
+                        new RawVector2(LayoutRectangle.X, LayoutRectangle.Y),
+                        layout,
+                        Convert(Color));
+                }
             }
         }
 

--- a/src/DesktopDuplication/Direct2DFont.cs
+++ b/src/DesktopDuplication/Direct2DFont.cs
@@ -1,0 +1,33 @@
+﻿using Captura;
+using SharpDX.DirectWrite;
+
+namespace DesktopDuplication
+{
+    public class Direct2DFont : IFont
+    {
+        public Direct2DFont(string FontFamily, int Size, Factory DirectWriteFactory)
+        {
+            this.FontFamily = FontFamily;
+            this.Size = Size;
+
+            try
+            {
+                TextFormat = new TextFormat(DirectWriteFactory, FontFamily, Size);
+            }
+            catch
+            {
+                TextFormat = new TextFormat(DirectWriteFactory, "Arial", Size);
+            }
+        }
+
+        public TextFormat TextFormat { get; }
+
+        public void Dispose()
+        {
+            TextFormat.Dispose();
+        }
+
+        public int Size { get; }
+        public string FontFamily { get; }
+    }
+}

--- a/src/Screna/Overlays/TextOverlay.cs
+++ b/src/Screna/Overlays/TextOverlay.cs
@@ -66,9 +66,9 @@ namespace Captura.Models
             if (string.IsNullOrWhiteSpace(text))
                 return;
 
-            var fontSize = _overlaySettings.FontSize;
+            var font = Editor.GetFont(_overlaySettings.FontFamily, _overlaySettings.FontSize);
 
-            var size = Editor.MeasureString(text, fontSize);
+            var size = Editor.MeasureString(text, font);
 
             int paddingX = _overlaySettings.HorizontalPadding, paddingY = _overlaySettings.VerticalPadding;
 
@@ -82,7 +82,7 @@ namespace Captura.Models
                 _overlaySettings.CornerRadius);
 
             Editor.DrawString(text,
-                fontSize,
+                font,
                 _overlaySettings.FontColor,
                 new RectangleF(rect.Left + paddingX, rect.Top + paddingY, size.Width, size.Height));
 


### PR DESCRIPTION
Requested in #363.

Default font is **Arial**.

- [x] Font picker Control
- [x] Font family setting
- [x] Overlay window preview
- [x] System.Drawing implementation
- [x] DirectWrite implementation
- [x] Same font size units for Preview, System.Drawing and DirectWrite.