### PR TITLE
Rolling Recording (Capture last N seconds)

### DIFF
--- a/src/Captura.Console/ConsoleManager.cs
+++ b/src/Captura.Console/ConsoleManager.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Captura.FFmpeg;
 using Captura.Models;
 using Captura.ViewModels;
 using static System.Console;
@@ -203,8 +204,10 @@ namespace Captura
             if (StartOptions.Encoder == null)
                 return;
 
+            var ffmpegExists = FFmpegService.FFmpegExists;
+
             // FFmpeg
-            if (FFmpegService.FFmpegExists && Regex.IsMatch(StartOptions.Encoder, @"^ffmpeg:\d+$"))
+            if (ffmpegExists && Regex.IsMatch(StartOptions.Encoder, @"^ffmpeg:\d+$"))
             {
                 var index = int.Parse(StartOptions.Encoder.Substring(7));
 
@@ -226,7 +229,7 @@ namespace Captura
             }
 
             // Stream
-            else if (FFmpegService.FFmpegExists && Regex.IsMatch(StartOptions.Encoder, @"^stream:\S+$"))
+            else if (ffmpegExists && Regex.IsMatch(StartOptions.Encoder, @"^stream:\S+$"))
             {
                 var url = StartOptions.Encoder.Substring(7);
                 _settings.FFmpeg.CustomStreamingUrl = url;
@@ -234,6 +237,16 @@ namespace Captura
                 _videoWritersViewModel.SelectedVideoWriterKind = ServiceProvider.Get<StreamingWriterProvider>();
 
                 _videoWritersViewModel.SelectedVideoWriter = StreamingWriterProvider.GetCustomStreamingCodec();
+            }
+
+            // Rolling
+            else if (ffmpegExists && Regex.IsMatch(StartOptions.Encoder, @"^roll:\d+$"))
+            {
+                var duration = int.Parse(StartOptions.Encoder.Substring(5));
+
+                _videoWritersViewModel.SelectedVideoWriterKind = ServiceProvider.Get<FFmpegWriterProvider>();
+
+                _videoWritersViewModel.SelectedVideoWriter = new FFmpegRollingWriterItem(duration);
             }
         }
 

--- a/src/Captura.Console/Properties/launchSettings.json
+++ b/src/Captura.Console/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Captura.Console": {
+      "commandName": "Project",
+      "commandLineArgs": "start --encoder roll:20 --speaker 0"
+    }
+  }
+}

--- a/src/Captura.FFmpeg/FFMpegLogItem.cs
+++ b/src/Captura.FFmpeg/FFMpegLogItem.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Captura.Models
 {
-    public class FFmpegLogItem : NotifyPropertyChanged
+    public class FFmpegLogItem : NotifyPropertyChanged, IFFmpegLogEntry
     {
         public string Name { get; }
 

--- a/src/Captura.FFmpeg/FFmpegModule.cs
+++ b/src/Captura.FFmpeg/FFmpegModule.cs
@@ -7,7 +7,6 @@ namespace Captura
         public static void Load(IBinder Binder)
         {
             Binder.BindSingleton<FFmpegSettings>();
-            Binder.BindSingleton<FFmpegLog>();
             Binder.BindAsInterfaceAndClass<IVideoWriterProvider, FFmpegWriterProvider>();
             Binder.BindAsInterfaceAndClass<IVideoWriterProvider, StreamingWriterProvider>();
 

--- a/src/Captura.FFmpeg/FFmpegService.cs
+++ b/src/Captura.FFmpeg/FFmpegService.cs
@@ -84,8 +84,8 @@ namespace Captura
                 },
                 EnableRaisingEvents = true
             };
-
-            var log = ServiceProvider.Get<FFmpegLog>();
+            
+            var log = ServiceProvider.Get<IFFmpegLogRepository>();
 
             var logItem = log.CreateNew(Path.GetFileName(FileName), Arguments);
                         

--- a/src/Captura.FFmpeg/IFFmpegLogEntry.cs
+++ b/src/Captura.FFmpeg/IFFmpegLogEntry.cs
@@ -1,0 +1,9 @@
+﻿namespace Captura.Models
+{
+    public interface IFFmpegLogEntry
+    {
+        void Write(string Line);
+
+        string GetCompleteLog();
+    }
+}

--- a/src/Captura.FFmpeg/IFFmpegLogRepository.cs
+++ b/src/Captura.FFmpeg/IFFmpegLogRepository.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Captura.Models
+{
+    public interface IFFmpegLogRepository : IEnumerable<IFFmpegLogEntry>
+    {
+        IFFmpegLogEntry CreateNew(string Name, string Args);
+
+        void Remove(IFFmpegLogEntry Entry);
+    }
+}

--- a/src/Captura.FFmpeg/Video/FFmpegRollingWriter.cs
+++ b/src/Captura.FFmpeg/Video/FFmpegRollingWriter.cs
@@ -12,7 +12,7 @@ namespace Captura.FFmpeg
         readonly long _frameCount;
         long _currentFrame = -1;
 
-        const int NoOfFiles = 3;
+        const int NoOfFiles = 2;
         int _currentFile = -1;
 
         static readonly TempFileVideoCodec TempVideoCodec = new TempFileVideoCodec();

--- a/src/Captura.FFmpeg/Video/FFmpegRollingWriter.cs
+++ b/src/Captura.FFmpeg/Video/FFmpegRollingWriter.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Captura.Models;
+
+namespace Captura.FFmpeg
+{
+    public class FFmpegRollingWriter : IVideoFileWriter
+    {
+        readonly VideoWriterArgs _videoWriterArgs;
+        readonly int _duration;
+        readonly long _frameCount;
+        long _currentFrame = -1;
+
+        const int NoOfFiles = 3;
+        int _currentFile = -1;
+
+        static readonly TempFileVideoCodec TempVideoCodec = new TempFileVideoCodec();
+
+        IVideoFileWriter _currentWriter;
+
+        string GetFileName(int Index)
+        {
+            return $"{_videoWriterArgs.FileName}.{Index}.mp4";
+        }
+
+        public FFmpegRollingWriter(VideoWriterArgs VideoWriterArgs, int Duration)
+        {
+            _videoWriterArgs = VideoWriterArgs;
+            _duration = Duration;
+            _frameCount = _videoWriterArgs.FrameRate * Duration;
+        }
+
+        public void Dispose()
+        {
+            _prevWriterDisposeTask?.Wait();
+            _currentWriter?.Dispose();
+
+            var currentFile = GetFileName(_currentFile);
+            var prevFile = GetFileName((_currentFile - 1 + NoOfFiles) % NoOfFiles);
+
+            var currentDuration = _currentFrame * 1000 / _videoWriterArgs.FrameRate;
+            var prevDuration = _duration * 1000 - currentDuration;
+
+            // Prev file only
+            if (currentDuration == 0 && File.Exists(prevFile))
+            {
+                File.Move(prevFile, _videoWriterArgs.FileName);
+            }
+            else if (prevDuration == 0 || !File.Exists(prevFile)) // Current file only
+            {
+                File.Move(currentFile, _videoWriterArgs.FileName);
+            }
+            else // Concat
+            {
+                var argsBuilder = new FFmpegArgsBuilder();
+
+                argsBuilder.AddInputFile(prevFile)
+                    .AddArg($"-ss {TimeSpan.FromMilliseconds(currentDuration):g}");
+
+                argsBuilder.AddInputFile(currentFile);
+
+                const string filter = "[0:v] [1:v] concat=n=2:v=1:a=0 [v]";
+
+                argsBuilder.AddOutputFile(_videoWriterArgs.FileName)
+                    .AddArg($"-filter_complex \"{filter}\"")
+                    .AddArg($"-map \"[v]\"");
+
+                var args = argsBuilder.GetArgs();
+
+                var process = FFmpegService.StartFFmpeg(args, _videoWriterArgs.FileName);
+
+                process.WaitForExit();
+            }
+
+            for (var i = 0; i < NoOfFiles; i++)
+            {
+                var filename = GetFileName(i);
+
+                if (File.Exists(filename))
+                {
+                    File.Delete(filename);
+                }
+            }
+        }
+
+        Task _prevWriterDisposeTask;
+
+        IVideoFileWriter GetWriter()
+        {
+            ++_currentFrame;
+            _currentFrame %= _frameCount;
+
+            if (_currentFrame == 0)
+            {
+                if (_currentWriter != null)
+                {
+                    _prevWriterDisposeTask?.Wait();
+
+                    var prevWriter = _currentWriter;
+                    _prevWriterDisposeTask = Task.Run(() => prevWriter.Dispose());
+
+                    _currentWriter = null;
+                }
+
+                ++_currentFile;
+                _currentFile %= NoOfFiles;
+            }
+
+            if (_currentWriter == null)
+            {
+                _currentWriter = TempVideoCodec.GetVideoFileWriter(new VideoWriterArgs
+                {
+                    FileName = GetFileName(_currentFile),
+                    VideoQuality = _videoWriterArgs.VideoQuality,
+                    FrameRate = _videoWriterArgs.FrameRate,
+                    ImageProvider = _videoWriterArgs.ImageProvider
+                });
+            }
+
+            return _currentWriter;
+        }
+
+        readonly object _syncLock = new object();
+
+        public void WriteFrame(IBitmapFrame Image)
+        {
+            IVideoFileWriter writer;
+
+            lock (_syncLock)
+            {
+                writer = GetWriter();
+            }
+
+            writer.WriteFrame(Image);
+        }
+
+        public bool SupportsAudio => false;
+
+        public void WriteAudio(byte[] Buffer, int Length) { }
+    }
+}

--- a/src/Captura.FFmpeg/Video/FFmpegRollingWriterItem.cs
+++ b/src/Captura.FFmpeg/Video/FFmpegRollingWriterItem.cs
@@ -1,0 +1,22 @@
+﻿using Captura.Models;
+
+namespace Captura.FFmpeg
+{
+    public class FFmpegRollingWriterItem : IVideoWriterItem
+    {
+        readonly int _duration;
+
+        public FFmpegRollingWriterItem(int Duration)
+        {
+            _duration = Duration;
+        }
+
+        public string Extension => ".mp4";
+        public string Description => "Capture Last n seconds";
+
+        public IVideoFileWriter GetVideoFileWriter(VideoWriterArgs Args)
+        {
+            return new FFmpegRollingWriter(Args, _duration);
+        }
+    }
+}

--- a/src/Captura.Fakes/FakeFFmpegLogRepository.cs
+++ b/src/Captura.Fakes/FakeFFmpegLogRepository.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Captura.Models
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class FakeFFmpegLogRepository : IFFmpegLogRepository
+    {
+        public IEnumerator<IFFmpegLogEntry> GetEnumerator()
+        {
+            yield break;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IFFmpegLogEntry CreateNew(string Name, string Args)
+        {
+            return new FFmpegLogItem(Name, Args);
+        }
+
+        public void Remove(IFFmpegLogEntry Entry)
+        {
+        }
+    }
+}

--- a/src/Captura.Fakes/FakesModule.cs
+++ b/src/Captura.Fakes/FakesModule.cs
@@ -15,6 +15,7 @@ namespace Captura
             Binder.Bind<IVideoSourcePicker>(() => FakeVideoSourcePicker.Instance);
             Binder.Bind<IAudioPlayer, FakeAudioPlayer>();
             Binder.Bind<IFFmpegViewsProvider, FakeFFmpegViewsProvider>();
+            Binder.Bind<IFFmpegLogRepository, FakeFFmpegLogRepository>();
         }
 
         public void Dispose() { }

--- a/src/Captura.ViewCore/FFmpegLog.cs
+++ b/src/Captura.ViewCore/FFmpegLog.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Captura.Models
 {
     // ReSharper disable once ClassNeverInstantiated.Global
-    public class FFmpegLog : NotifyPropertyChanged
+    public class FFmpegLog : NotifyPropertyChanged, IFFmpegLogRepository
     {
         public FFmpegLog()
         {
@@ -26,6 +28,20 @@ namespace Captura.Models
         public void Remove(FFmpegLogItem Item)
         {
             _logItems.Remove(Item);
+        }
+
+        public IEnumerator<IFFmpegLogEntry> GetEnumerator() => _logItems.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        IFFmpegLogEntry IFFmpegLogRepository.CreateNew(string Name, string Args) => CreateNew(Name, Args);
+
+        void IFFmpegLogRepository.Remove(IFFmpegLogEntry Entry)
+        {
+            if (Entry is FFmpegLogItem logItem)
+            {
+                Remove(logItem);
+            }
         }
     }
 }

--- a/src/Captura.ViewCore/ViewCoreModule.cs
+++ b/src/Captura.ViewCore/ViewCoreModule.cs
@@ -1,4 +1,6 @@
-﻿namespace Captura.ViewModels
+﻿using Captura.Models;
+
+namespace Captura.ViewModels
 {
     public class ViewCoreModule : IModule
     {
@@ -22,6 +24,8 @@
             Binder.BindSingleton<CustomOverlaysViewModel>();
             Binder.BindSingleton<CustomImageOverlaysViewModel>();
             Binder.BindSingleton<CensorOverlaysViewModel>();
+
+            Binder.Bind<IFFmpegLogRepository, FFmpegLog>();
         }
 
         public void Dispose() { }


### PR DESCRIPTION
Requested in #182 

Capture last N seconds mode added for Console.
This feature will **NOT** be implemented for the UI version due to the involved complications.

Implemented as a new encoder: `roll:<duration>` where duration is specified in seconds.

```
captura-cli start --encoder roll:60
```

Separate file for webcam and separate audio files for every source may not work as intended in this mode.

Added `IFFmpegLogRepository` and a Fake implementation which is now used for Console version since lots of logs are being created in this mode.