### PR TITLE
MediaFoundation SinkWriter

### DIFF
--- a/src/Captura.Base/Images/IBitmapFrame.cs
+++ b/src/Captura.Base/Images/IBitmapFrame.cs
@@ -9,5 +9,7 @@ namespace Captura
         int Height { get; }
 
         void CopyTo(byte[] Buffer, int Length);
+
+        void CopyTo(IntPtr Buffer, int Length);
     }
 }

--- a/src/Captura.Base/Images/IFrameWrapper.cs
+++ b/src/Captura.Base/Images/IFrameWrapper.cs
@@ -1,0 +1,7 @@
+﻿namespace Captura.Models
+{
+    public interface IFrameWrapper
+    {
+        IBitmapFrame Frame { get; }
+    }
+}

--- a/src/Captura.Base/Images/IImageProvider.cs
+++ b/src/Captura.Base/Images/IImageProvider.cs
@@ -26,6 +26,6 @@ namespace Captura
 
         Func<Point, Point> PointTransform { get; }
 
-        Type FrameType { get; }
+        Type EditorType { get; }
     }
 }

--- a/src/Captura.Base/Images/IImageProvider.cs
+++ b/src/Captura.Base/Images/IImageProvider.cs
@@ -25,5 +25,7 @@ namespace Captura
         int Width { get; }
 
         Func<Point, Point> PointTransform { get; }
+
+        Type FrameType { get; }
     }
 }

--- a/src/Captura.Base/Images/RepeatFrame.cs
+++ b/src/Captura.Base/Images/RepeatFrame.cs
@@ -90,5 +90,10 @@ namespace Captura
         {
             throw new NotImplementedException();
         }
+
+        void IBitmapFrame.CopyTo(IntPtr Buffer, int Length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Captura.Core/CoreModule.cs
+++ b/src/Captura.Core/CoreModule.cs
@@ -2,6 +2,7 @@
 using Captura.Models;
 using Captura.NAudio;
 using Captura.ViewModels;
+using DesktopDuplication;
 
 namespace Captura
 {
@@ -35,10 +36,15 @@ namespace Captura
 
             Binder.Bind<ILocalizationProvider>(() => LanguageManager.Instance);
 
+            MfManager.Startup();
+
             WindowsModule.Load(Binder);
         }
 
-        public void Dispose() { }
+        public void Dispose()
+        {
+            MfManager.Shutdown();
+        }
 
         static void BindImageWriters(IBinder Binder)
         {
@@ -98,6 +104,7 @@ namespace Captura
 
         static void BindVideoWriterProviders(IBinder Binder)
         {
+            Binder.BindAsInterfaceAndClass<IVideoWriterProvider, MfWriterProvider>();
             Binder.BindAsInterfaceAndClass<IVideoWriterProvider, SharpAviWriterProvider>();
             Binder.BindAsInterfaceAndClass<IVideoWriterProvider, DiscardWriterProvider>();
         }

--- a/src/Captura.Core/CoreModule.cs
+++ b/src/Captura.Core/CoreModule.cs
@@ -12,6 +12,9 @@ namespace Captura
         {
             Binder.Bind<IAudioWriterItem, WaveItem>();
 
+            MfManager.Startup();
+            Binder.BindAsInterfaceAndClass<IVideoWriterProvider, MfWriterProvider>();
+
             FFmpegModule.Load(Binder);
 
             BindViewModels(Binder);
@@ -35,8 +38,6 @@ namespace Captura
             Binder.BindSingleton<HotKeyManager>();
 
             Binder.Bind<ILocalizationProvider>(() => LanguageManager.Instance);
-
-            MfManager.Startup();
 
             WindowsModule.Load(Binder);
         }
@@ -104,7 +105,6 @@ namespace Captura
 
         static void BindVideoWriterProviders(IBinder Binder)
         {
-            Binder.BindAsInterfaceAndClass<IVideoWriterProvider, MfWriterProvider>();
             Binder.BindAsInterfaceAndClass<IVideoWriterProvider, SharpAviWriterProvider>();
             Binder.BindAsInterfaceAndClass<IVideoWriterProvider, DiscardWriterProvider>();
         }

--- a/src/Captura.Core/CoreModule.cs
+++ b/src/Captura.Core/CoreModule.cs
@@ -12,8 +12,11 @@ namespace Captura
         {
             Binder.Bind<IAudioWriterItem, WaveItem>();
 
-            MfManager.Startup();
-            Binder.BindAsInterfaceAndClass<IVideoWriterProvider, MfWriterProvider>();
+            if (Windows8OrAbove)
+            {
+                MfManager.Startup();
+                Binder.BindAsInterfaceAndClass<IVideoWriterProvider, MfWriterProvider>();
+            }
 
             FFmpegModule.Load(Binder);
 
@@ -44,7 +47,10 @@ namespace Captura
 
         public void Dispose()
         {
-            MfManager.Shutdown();
+            if (Windows8OrAbove)
+            {
+                MfManager.Shutdown();
+            }
         }
 
         static void BindImageWriters(IBinder Binder)

--- a/src/Captura.Core/Settings/Models/VideoSettings.cs
+++ b/src/Captura.Core/Settings/Models/VideoSettings.cs
@@ -4,7 +4,7 @@
     {
         public string WriterKind
         {
-            get => Get("FFmpeg");
+            get => Get("");
             set => Set(value);
         }
         

--- a/src/Captura.Core/WebcamImageProvider.cs
+++ b/src/Captura.Core/WebcamImageProvider.cs
@@ -38,5 +38,7 @@ namespace Captura.Webcam
         public int Width => _webcamModel.WebcamCapture?.Width ?? 0;
 
         public Func<Point, Point> PointTransform { get; } = P => P;
+
+        public Type FrameType { get; } = typeof(GraphicsEditor);
     }
 }

--- a/src/Captura.Core/WebcamImageProvider.cs
+++ b/src/Captura.Core/WebcamImageProvider.cs
@@ -39,6 +39,6 @@ namespace Captura.Webcam
 
         public Func<Point, Point> PointTransform { get; } = P => P;
 
-        public Type FrameType { get; } = typeof(GraphicsEditor);
+        public Type EditorType { get; } = typeof(GraphicsEditor);
     }
 }

--- a/src/Captura.Windows/Capture/RegionProvider.cs
+++ b/src/Captura.Windows/Capture/RegionProvider.cs
@@ -66,5 +66,7 @@ namespace Screna
 
         public int Height { get; }
         public int Width { get; }
+
+        public Type FrameType { get; } = typeof(GraphicsEditor);
     }
 }

--- a/src/Captura.Windows/Capture/RegionProvider.cs
+++ b/src/Captura.Windows/Capture/RegionProvider.cs
@@ -67,6 +67,6 @@ namespace Screna
         public int Height { get; }
         public int Width { get; }
 
-        public Type FrameType { get; } = typeof(GraphicsEditor);
+        public Type EditorType { get; } = typeof(GraphicsEditor);
     }
 }

--- a/src/Captura.Windows/Capture/WindowProvider.cs
+++ b/src/Captura.Windows/Capture/WindowProvider.cs
@@ -130,5 +130,7 @@ namespace Screna
             User32.ReleaseDC(IntPtr.Zero, _hdcSrc);
             Gdi32.DeleteObject(_hBitmap);
         }
+
+        public Type FrameType { get; } = typeof(GraphicsEditor);
     }
 }

--- a/src/Captura.Windows/Capture/WindowProvider.cs
+++ b/src/Captura.Windows/Capture/WindowProvider.cs
@@ -131,6 +131,6 @@ namespace Screna
             Gdi32.DeleteObject(_hBitmap);
         }
 
-        public Type FrameType { get; } = typeof(GraphicsEditor);
+        public Type EditorType { get; } = typeof(GraphicsEditor);
     }
 }

--- a/src/Captura.Windows/Imaging/DrawingFrameBase.cs
+++ b/src/Captura.Windows/Imaging/DrawingFrameBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using Captura;
@@ -28,6 +29,20 @@ namespace Screna
             try
             {
                 Marshal.Copy(bits.Scan0, Buffer, 0, Length);
+            }
+            finally
+            {
+                Bitmap.UnlockBits(bits);
+            }
+        }
+
+        public void CopyTo(IntPtr Buffer, int Length)
+        {
+            var bits = Bitmap.LockBits(new Rectangle(Point.Empty, Bitmap.Size), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+
+            try
+            {
+                Kernel32.CopyMemory(Buffer, bits.Scan0, (uint)Length);
             }
             finally
             {

--- a/src/Captura.Windows/Native/Kernel32.cs
+++ b/src/Captura.Windows/Native/Kernel32.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Captura
+{
+    public class Kernel32
+    {
+        const string DllName = "Kernel32";
+
+        [DllImport(DllName)]
+        public static extern void CopyMemory(IntPtr Dest, IntPtr Src, uint Count);
+    }
+}

--- a/src/Captura/Pages/VideoEncoderPage.xaml
+++ b/src/Captura/Pages/VideoEncoderPage.xaml
@@ -17,12 +17,13 @@
                       SelectionMode="Single">
                 <ListView.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <UniformGrid Rows="1"/>
+                        <StackPanel Orientation="Horizontal"/>
                     </ItemsPanelTemplate>
                 </ListView.ItemsPanel>
                 <ListView.ItemTemplate>
                     <DataTemplate>
-                        <Grid Background="#01000000">
+                        <Grid Background="#01000000"
+                              MinWidth="60">
                             <Grid.ToolTip>
                                 <StackPanel MinWidth="200">
                                     <TextBlock Text="{Binding Name, Mode=OneWay}"

--- a/src/DesktopDuplication/DeskDuplImageProvider.cs
+++ b/src/DesktopDuplication/DeskDuplImageProvider.cs
@@ -37,6 +37,6 @@ namespace Captura.Models
             _dupl?.Dispose();
         }
 
-        public Type FrameType { get; } = typeof(Texture2DFrame);
+        public Type EditorType { get; } = typeof(Direct2DEditor);
     }
 }

--- a/src/DesktopDuplication/DeskDuplImageProvider.cs
+++ b/src/DesktopDuplication/DeskDuplImageProvider.cs
@@ -36,5 +36,7 @@ namespace Captura.Models
         {
             _dupl?.Dispose();
         }
+
+        public Type FrameType { get; } = typeof(Texture2DFrame);
     }
 }

--- a/src/DesktopDuplication/DesktopDuplication.csproj
+++ b/src/DesktopDuplication/DesktopDuplication.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Base\Captura.Base.csproj" />
+    <ProjectReference Include="..\Captura.Windows\Captura.Windows.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />

--- a/src/DesktopDuplication/DesktopDuplication.csproj
+++ b/src/DesktopDuplication/DesktopDuplication.csproj
@@ -4,10 +4,12 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Base\Captura.Base.csproj" />
+    <ProjectReference Include="..\Screna\Screna.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.1.0" />
     <PackageReference Include="SharpDX.Direct3D9" Version="4.2.0" />
+    <PackageReference Include="SharpDX.MediaFoundation" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/src/DesktopDuplication/DesktopDuplication.csproj
+++ b/src/DesktopDuplication/DesktopDuplication.csproj
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Base\Captura.Base.csproj" />
-    <ProjectReference Include="..\Screna\Screna.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />

--- a/src/DesktopDuplication/Direct2DEditor.cs
+++ b/src/DesktopDuplication/Direct2DEditor.cs
@@ -12,6 +12,7 @@ using Bitmap = SharpDX.Direct2D1.Bitmap;
 using BitmapInterpolationMode = SharpDX.Direct2D1.BitmapInterpolationMode;
 using Color = System.Drawing.Color;
 using PixelFormat = SharpDX.WIC.PixelFormat;
+using Point = System.Drawing.Point;
 using Rectangle = System.Drawing.Rectangle;
 using RectangleF = System.Drawing.RectangleF;
 

--- a/src/DesktopDuplication/MediaFoundation/MfItem.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfItem.cs
@@ -8,9 +8,9 @@ namespace Captura.Models
         readonly Device _device;
 
         public string Extension => ".mp4";
-        public string Description { get; } = "mp4";
+        public string Description { get; } = "Encode to Mp4: H.264 with AAC audio using Media Foundation Hardware encoder";
 
-        readonly string _name = "mf";
+        readonly string _name = "MF";
 
         public MfItem(Device Device)
         {
@@ -21,12 +21,7 @@ namespace Captura.Models
 
         public virtual IVideoFileWriter GetVideoFileWriter(VideoWriterArgs Args)
         {
-            return new MfWriter(Args.FrameRate,
-                Args.ImageProvider.Width,
-                Args.ImageProvider.Height,
-                Args.FileName,
-                _device,
-                Args.AudioProvider);
+            return new MfWriter(Args, _device);
         }
     }
 }

--- a/src/DesktopDuplication/MediaFoundation/MfItem.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfItem.cs
@@ -25,7 +25,8 @@ namespace Captura.Models
                 Args.ImageProvider.Width,
                 Args.ImageProvider.Height,
                 Args.FileName,
-                _device);
+                _device,
+                Args.AudioProvider);
         }
     }
 }

--- a/src/DesktopDuplication/MediaFoundation/MfItem.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfItem.cs
@@ -1,0 +1,31 @@
+﻿using DesktopDuplication;
+using SharpDX.Direct3D11;
+
+namespace Captura.Models
+{
+    public class MfItem : IVideoWriterItem
+    {
+        readonly Device _device;
+
+        public string Extension => ".mp4";
+        public string Description { get; } = "mp4";
+
+        readonly string _name = "mf";
+
+        public MfItem(Device Device)
+        {
+            _device = Device;
+        }
+
+        public override string ToString() => _name;
+
+        public virtual IVideoFileWriter GetVideoFileWriter(VideoWriterArgs Args)
+        {
+            return new MfWriter(Args.FrameRate,
+                Args.ImageProvider.Width,
+                Args.ImageProvider.Height,
+                Args.FileName,
+                _device);
+        }
+    }
+}

--- a/src/DesktopDuplication/MediaFoundation/MfManager.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfManager.cs
@@ -1,0 +1,16 @@
+﻿using SharpDX.MediaFoundation;
+
+namespace DesktopDuplication
+{
+    public static class MfManager
+    {
+        public static void Startup()
+        {
+            MediaManager.Startup();
+        }
+        public static void Shutdown()
+        {
+            MediaFactory.Shutdown();
+        }
+    }
+}

--- a/src/DesktopDuplication/MediaFoundation/MfWriter.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfWriter.cs
@@ -231,7 +231,7 @@ namespace DesktopDuplication
                 {
                     Write(frame.Texture);
                 }
-                else if (Image is MultiDisposeFrame wrapper && wrapper.Frame is Texture2DFrame textureFrame)
+                else if (Image is IFrameWrapper wrapper && wrapper.Frame is Texture2DFrame textureFrame)
                 {
                     Write(textureFrame.Texture);
                 }

--- a/src/DesktopDuplication/MediaFoundation/MfWriter.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfWriter.cs
@@ -66,9 +66,7 @@ namespace DesktopDuplication
 
         public MfWriter(VideoWriterArgs Args, Device Device)
         {
-            if (Args.ImageProvider is DeskDuplImageProvider
-                || Args.ImageProvider is OverlayedImageProvider overlayImgPr
-                && overlayImgPr.ImageProvider is DeskDuplImageProvider)
+            if (Args.ImageProvider.FrameType == typeof(Texture2DFrame))
             {
                 _inputFormat = VideoFormatGuids.NV12;
             }

--- a/src/DesktopDuplication/MediaFoundation/MfWriter.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfWriter.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Diagnostics;
+using Captura;
+using Screna;
+using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using SharpDX.MediaFoundation;
+using Device = SharpDX.Direct3D11.Device;
+
+namespace DesktopDuplication
+{
+    public class MfWriter : IVideoFileWriter
+    {
+        readonly Device _device;
+        const int BitRate = 8_000_000;
+        readonly Guid _encodingFormat = VideoFormatGuids.H264;
+        readonly Guid _inputFormat = VideoFormatGuids.NV12;
+        readonly Stopwatch _stopwatch = new Stopwatch();
+        readonly long _frameDuration;
+        readonly SinkWriter _writer;
+        readonly int _streamIndex;
+
+        static long PackLong(int Left, int Right)
+        {
+            return new PackedLong
+            {
+                Low = Right,
+                High = Left
+            }.Long;
+        }
+
+        public MfWriter(int Fps, int Width, int Height, string FileName, Device Device)
+        {
+            _device = Device;
+
+            _frameDuration = 10_000_000 / Fps;
+
+            var attr = new MediaAttributes(6);
+
+            attr.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
+            attr.Set(SinkWriterAttributeKeys.ReadwriteDisableConverters, 0);
+            attr.Set(TranscodeAttributeKeys.TranscodeContainertype, TranscodeContainerTypeGuids.Mpeg4);
+            attr.Set(SinkWriterAttributeKeys.LowLatency, true);
+            attr.Set(SinkWriterAttributeKeys.DisableThrottling, 1);
+
+            var devMan = new DXGIDeviceManager();
+            devMan.ResetDevice(Device);
+            attr.Set(SinkWriterAttributeKeys.D3DManager, devMan);
+
+            _writer = MediaFactory.CreateSinkWriterFromURL(FileName, null, attr);
+
+            using (var mediaTypeOut = new MediaType())
+            {
+                mediaTypeOut.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+                mediaTypeOut.Set(MediaTypeAttributeKeys.Subtype, _encodingFormat);
+                mediaTypeOut.Set(MediaTypeAttributeKeys.AvgBitrate, BitRate);
+                mediaTypeOut.Set(MediaTypeAttributeKeys.InterlaceMode, (int)VideoInterlaceMode.Progressive);
+                mediaTypeOut.Set(MediaTypeAttributeKeys.FrameSize, PackLong(Width, Height));
+                mediaTypeOut.Set(MediaTypeAttributeKeys.FrameRate, PackLong(Fps, 1));
+                mediaTypeOut.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackLong(1, 1));
+                _writer.AddStream(mediaTypeOut, out _streamIndex);
+            }
+
+            using (var mediaTypeIn = new MediaType())
+            {
+                mediaTypeIn.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+                mediaTypeIn.Set(MediaTypeAttributeKeys.Subtype, _inputFormat);
+                mediaTypeIn.Set(MediaTypeAttributeKeys.InterlaceMode, (int)VideoInterlaceMode.Progressive);
+                mediaTypeIn.Set(MediaTypeAttributeKeys.FrameSize, PackLong(Width, Height));
+                mediaTypeIn.Set(MediaTypeAttributeKeys.FrameRate, PackLong(Fps, 1));
+                mediaTypeIn.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackLong(1, 1));
+                _writer.SetInputMediaType(_streamIndex, mediaTypeIn, null);
+            }
+
+            _writer.BeginWriting();
+            _stopwatch.Start();
+
+            _copyTexture = new Texture2D(Device, new Texture2DDescription
+            {
+                CpuAccessFlags = CpuAccessFlags.Read,
+                BindFlags = BindFlags.None,
+                Format = Format.B8G8R8A8_UNorm,
+                Width = Width,
+                Height = Height,
+                OptionFlags = ResourceOptionFlags.None,
+                MipLevels = 1,
+                ArraySize = 1,
+                SampleDescription = { Count = 1, Quality = 0 },
+                Usage = ResourceUsage.Staging
+            });
+
+            _sample = MediaFactory.CreateVideoSampleFromSurface(null);
+                
+            // Create the media buffer from the texture
+            MediaFactory.CreateDXGISurfaceBuffer(typeof(Texture2D).GUID, _copyTexture, 0, false, out _mediaBuffer);
+
+            using (var buffer2D = _mediaBuffer.QueryInterface<Buffer2D>())
+                _mediaBuffer.CurrentLength = buffer2D.ContiguousLength;
+
+            // Attach the created buffer to the sample
+            _sample.AddBuffer(_mediaBuffer);
+        }
+
+        bool _first = true;
+
+        readonly object _syncLock = new object();
+
+        public void Write(Sample Sample)
+        {
+            lock (_syncLock)
+            {
+                if (_disposed)
+                    return;
+
+                Sample.SampleTime = _stopwatch.Elapsed.Ticks;
+                Sample.SampleDuration = _frameDuration;
+                
+                if (_first)
+                {
+                    _writer.SendStreamTick(_streamIndex, Sample.SampleTime);
+                    Sample.Set(SampleAttributeKeys.Discontinuity, true);
+                    _first = false;
+                }
+                _writer.WriteSample(_streamIndex, Sample);
+            }
+        }
+
+        Texture2D _copyTexture;
+        Sample _sample;
+        MediaBuffer _mediaBuffer;
+
+        void Write(Texture2D Texture)
+        {
+            _device.ImmediateContext.CopyResource(Texture, _copyTexture);
+
+            Write(_sample);
+        }
+
+        bool _disposed;
+
+        public void Dispose()
+        {
+            lock (_syncLock)
+            {
+                _disposed = true;
+                _writer.Finalize();
+                _writer.Dispose();
+                _stopwatch.Stop();
+
+                _copyTexture.Dispose();
+                _copyTexture = null;
+
+                _sample.Dispose();
+                _sample = null;
+
+                _mediaBuffer.Dispose();
+                _mediaBuffer = null;
+            }
+        }
+
+        public void WriteFrame(IBitmapFrame Image)
+        {
+            if (Image is Texture2DFrame frame)
+            {
+                Write(frame.Texture);
+            }
+            else if (Image is MultiDisposeFrame wrapper && wrapper.Frame is Texture2DFrame textureFrame)
+            {
+                Write(textureFrame.Texture);
+            }
+        }
+
+        public bool SupportsAudio => false;
+
+        public void WriteAudio(byte[] Buffer, int Length)
+        {
+        }
+    }
+}

--- a/src/DesktopDuplication/MediaFoundation/MfWriter.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfWriter.cs
@@ -66,7 +66,7 @@ namespace DesktopDuplication
 
         public MfWriter(VideoWriterArgs Args, Device Device)
         {
-            if (Args.ImageProvider.FrameType == typeof(Texture2DFrame))
+            if (Args.ImageProvider.EditorType == typeof(Direct2DEditor))
             {
                 _inputFormat = VideoFormatGuids.NV12;
             }

--- a/src/DesktopDuplication/MediaFoundation/MfWriter.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfWriter.cs
@@ -47,6 +47,23 @@ namespace DesktopDuplication
             }.Long;
         }
 
+        MediaAttributes GetSinkWriterAttributes(Device Device)
+        {
+            var attr = new MediaAttributes(6);
+
+            attr.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
+            attr.Set(SinkWriterAttributeKeys.ReadwriteDisableConverters, 0);
+            attr.Set(TranscodeAttributeKeys.TranscodeContainertype, TranscodeContainerTypeGuids.Mpeg4);
+            attr.Set(SinkWriterAttributeKeys.LowLatency, true);
+            attr.Set(SinkWriterAttributeKeys.DisableThrottling, 1);
+
+            var devMan = new DXGIDeviceManager();
+            devMan.ResetDevice(Device);
+            attr.Set(SinkWriterAttributeKeys.D3DManager, devMan);
+
+            return attr;
+        }
+
         public MfWriter(VideoWriterArgs Args, Device Device)
         {
             if (Args.ImageProvider is DeskDuplImageProvider
@@ -61,17 +78,7 @@ namespace DesktopDuplication
 
             _frameDuration = TenPower7 / Args.FrameRate;
 
-            var attr = new MediaAttributes(6);
-
-            attr.Set(SinkWriterAttributeKeys.ReadwriteEnableHardwareTransforms, 1);
-            attr.Set(SinkWriterAttributeKeys.ReadwriteDisableConverters, 0);
-            attr.Set(TranscodeAttributeKeys.TranscodeContainertype, TranscodeContainerTypeGuids.Mpeg4);
-            attr.Set(SinkWriterAttributeKeys.LowLatency, true);
-            attr.Set(SinkWriterAttributeKeys.DisableThrottling, 1);
-
-            var devMan = new DXGIDeviceManager();
-            devMan.ResetDevice(Device);
-            attr.Set(SinkWriterAttributeKeys.D3DManager, devMan);
+            var attr = GetSinkWriterAttributes(Device);
 
             _writer = MediaFactory.CreateSinkWriterFromURL(Args.FileName, null, attr);
 

--- a/src/DesktopDuplication/MediaFoundation/MfWriter.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfWriter.cs
@@ -28,7 +28,6 @@ namespace DesktopDuplication
         const int NoOfChannels = 2;
         const int SampleRate = 44100;
         const int BitsPerSample = 16;
-        const int Bitrate = 16_000;
         const int TenPower7 = 10_000_000;
         readonly int _bufferSize;
 
@@ -120,7 +119,7 @@ namespace DesktopDuplication
                     audioTypeOut.Set(MediaTypeAttributeKeys.AudioNumChannels, NoOfChannels);
                     audioTypeOut.Set(MediaTypeAttributeKeys.AudioBitsPerSample, BitsPerSample);
                     audioTypeOut.Set(MediaTypeAttributeKeys.AudioSamplesPerSecond, SampleRate);
-                    audioTypeOut.Set(MediaTypeAttributeKeys.AudioAvgBytesPerSecond, Bitrate);
+                    audioTypeOut.Set(MediaTypeAttributeKeys.AudioAvgBytesPerSecond, GetAacBitrate(Args.AudioQuality));
                     _writer.AddStream(audioTypeOut, out _);
                 }
 
@@ -161,6 +160,19 @@ namespace DesktopDuplication
 
             // Attach the created buffer to the sample
             _sample.AddBuffer(_mediaBuffer);
+        }
+
+        int GetAacBitrate(int AudioQuality)
+        {
+            var i = (AudioQuality - 1) / 25;
+
+            return new[]
+            {
+                12_000,
+                16_000,
+                20_000,
+                24_000
+            }[i];
         }
 
         readonly object _syncLock = new object();

--- a/src/DesktopDuplication/MediaFoundation/MfWriterProvider.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfWriterProvider.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using SharpDX.Direct3D;
+using SharpDX.Direct3D11;
+
+namespace Captura.Models
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class MfWriterProvider : IVideoWriterProvider
+    {
+        readonly Device _device;
+
+        public MfWriterProvider()
+        {
+            _device = new Device(DriverType.Hardware, DeviceCreationFlags.BgraSupport);
+        }
+
+        public string Name => "mf";
+
+        public IEnumerator<IVideoWriterItem> GetEnumerator()
+        {
+            yield return new MfItem(_device);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public override string ToString() => Name;
+
+        public string Description => @"mf";
+    }
+}

--- a/src/DesktopDuplication/MediaFoundation/MfWriterProvider.cs
+++ b/src/DesktopDuplication/MediaFoundation/MfWriterProvider.cs
@@ -15,7 +15,7 @@ namespace Captura.Models
             _device = new Device(DriverType.Hardware, DeviceCreationFlags.BgraSupport);
         }
 
-        public string Name => "mf";
+        public string Name => "MF";
 
         public IEnumerator<IVideoWriterItem> GetEnumerator()
         {
@@ -26,6 +26,6 @@ namespace Captura.Models
 
         public override string ToString() => Name;
 
-        public string Description => @"mf";
+        public string Description => "Encode to Mp4: H.264 with AAC audio using Media Foundation Hardware encoder";
     }
 }

--- a/src/DesktopDuplication/MediaFoundation/PackedLong.cs
+++ b/src/DesktopDuplication/MediaFoundation/PackedLong.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.InteropServices;
+
+namespace DesktopDuplication
+{
+    [StructLayout(LayoutKind.Explicit)]
+    public class PackedLong
+    {
+        [FieldOffset(0)]
+        public long Long;
+
+        [FieldOffset(0)]
+        public int Low;
+
+        [FieldOffset(sizeof(int))]
+        public int High;
+    }
+}

--- a/src/DesktopDuplication/MediaFoundation/RateControlMode.cs
+++ b/src/DesktopDuplication/MediaFoundation/RateControlMode.cs
@@ -1,0 +1,13 @@
+﻿namespace DesktopDuplication
+{
+    enum RateControlMode
+    {
+        CBR,
+        PeakConstrainedVBR,
+        UnconstrainedVBR,
+        Quality,
+        LowDelayVBR,
+        GlobalVBR,
+        GlobalLowDelayVBR
+    };
+}

--- a/src/DesktopDuplication/Texture2DFrame.cs
+++ b/src/DesktopDuplication/Texture2DFrame.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using Captura;
 using SharpDX.Direct3D11;
 using Device = SharpDX.Direct3D11.Device;
@@ -37,6 +38,20 @@ namespace DesktopDuplication
             try
             {
                 Marshal.Copy(mapSource.DataPointer, Buffer, 0, Length);
+            }
+            finally
+            {
+                Device.ImmediateContext.UnmapSubresource(Texture, 0);
+            }
+        }
+
+        public void CopyTo(IntPtr Buffer, int Length)
+        {
+            var mapSource = Device.ImmediateContext.MapSubresource(Texture, 0, MapMode.Read, MapFlags.None);
+
+            try
+            {
+                Kernel32.CopyMemory(Buffer, mapSource.DataPointer, (uint)Length);
             }
             finally
             {

--- a/src/Screna/ImageProviders/OverlayedImageProvider.cs
+++ b/src/Screna/ImageProviders/OverlayedImageProvider.cs
@@ -10,7 +10,7 @@ namespace Screna
     public class OverlayedImageProvider : IImageProvider
     {
         IOverlay[] _overlays;
-        IImageProvider _imageProvider;
+        public IImageProvider ImageProvider { get; private set; }
         
         /// <summary>
         /// Creates a new instance of <see cref="OverlayedImageProvider"/>.
@@ -20,7 +20,7 @@ namespace Screna
         /// <param name="Transform">Point Transform Function.</param>
         public OverlayedImageProvider(IImageProvider ImageProvider, params IOverlay[] Overlays)
         {
-            _imageProvider = ImageProvider ?? throw new ArgumentNullException(nameof(ImageProvider));
+            this.ImageProvider = ImageProvider ?? throw new ArgumentNullException(nameof(ImageProvider));
             _overlays = Overlays ?? throw new ArgumentNullException(nameof(Overlays));
 
             Width = ImageProvider.Width;
@@ -30,16 +30,19 @@ namespace Screna
         /// <inheritdoc />
         public IEditableFrame Capture()
         {
-            var bmp = _imageProvider.Capture();
+            var bmp = ImageProvider.Capture();
             
             // Overlays should have already been drawn on previous frame
             if (bmp is RepeatFrame)
             {
                 return bmp;
             }
-            
-            foreach (var overlay in _overlays)
-                overlay?.Draw(bmp, _imageProvider.PointTransform);
+
+            if (_overlays != null)
+            {
+                foreach (var overlay in _overlays)
+                    overlay?.Draw(bmp, ImageProvider.PointTransform);
+            }
             
             return bmp;
         }
@@ -55,12 +58,12 @@ namespace Screna
         /// <inheritdoc />
         public void Dispose()
         {
-            _imageProvider.Dispose();
+            ImageProvider.Dispose();
 
             foreach (var overlay in _overlays)
                 overlay?.Dispose();
 
-            _imageProvider = null;
+            ImageProvider = null;
             _overlays = null;
         }
     }

--- a/src/Screna/ImageProviders/OverlayedImageProvider.cs
+++ b/src/Screna/ImageProviders/OverlayedImageProvider.cs
@@ -67,6 +67,6 @@ namespace Screna
             _overlays = null;
         }
 
-        public Type FrameType => _imageProvider.FrameType;
+        public Type EditorType => _imageProvider.EditorType;
     }
 }

--- a/src/Screna/ImageProviders/OverlayedImageProvider.cs
+++ b/src/Screna/ImageProviders/OverlayedImageProvider.cs
@@ -10,7 +10,7 @@ namespace Screna
     public class OverlayedImageProvider : IImageProvider
     {
         IOverlay[] _overlays;
-        public IImageProvider ImageProvider { get; private set; }
+        IImageProvider _imageProvider;
         
         /// <summary>
         /// Creates a new instance of <see cref="OverlayedImageProvider"/>.
@@ -20,7 +20,7 @@ namespace Screna
         /// <param name="Transform">Point Transform Function.</param>
         public OverlayedImageProvider(IImageProvider ImageProvider, params IOverlay[] Overlays)
         {
-            this.ImageProvider = ImageProvider ?? throw new ArgumentNullException(nameof(ImageProvider));
+            _imageProvider = ImageProvider ?? throw new ArgumentNullException(nameof(ImageProvider));
             _overlays = Overlays ?? throw new ArgumentNullException(nameof(Overlays));
 
             Width = ImageProvider.Width;
@@ -30,7 +30,7 @@ namespace Screna
         /// <inheritdoc />
         public IEditableFrame Capture()
         {
-            var bmp = ImageProvider.Capture();
+            var bmp = _imageProvider.Capture();
             
             // Overlays should have already been drawn on previous frame
             if (bmp is RepeatFrame)
@@ -41,7 +41,7 @@ namespace Screna
             if (_overlays != null)
             {
                 foreach (var overlay in _overlays)
-                    overlay?.Draw(bmp, ImageProvider.PointTransform);
+                    overlay?.Draw(bmp, _imageProvider.PointTransform);
             }
             
             return bmp;
@@ -58,13 +58,15 @@ namespace Screna
         /// <inheritdoc />
         public void Dispose()
         {
-            ImageProvider.Dispose();
+            _imageProvider.Dispose();
 
             foreach (var overlay in _overlays)
                 overlay?.Dispose();
 
-            ImageProvider = null;
+            _imageProvider = null;
             _overlays = null;
         }
+
+        public Type FrameType => _imageProvider.FrameType;
     }
 }

--- a/src/Screna/MultiDisposeFrame.cs
+++ b/src/Screna/MultiDisposeFrame.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using Captura;
+using Captura.Models;
 
 namespace Screna
 {
-    public class MultiDisposeFrame : IBitmapFrame
+    public class MultiDisposeFrame : IBitmapFrame, IFrameWrapper
     {
         int _count;
 

--- a/src/Screna/MultiDisposeFrame.cs
+++ b/src/Screna/MultiDisposeFrame.cs
@@ -48,5 +48,10 @@ namespace Screna
         {
             Frame.CopyTo(Buffer, Length);
         }
+
+        public void CopyTo(IntPtr Buffer, int Length)
+        {
+            Frame.CopyTo(Buffer, Length);
+        }
     }
 }


### PR DESCRIPTION
Using `MediaFoundation` `SinkWriter` considerably reduces CPU usage.

- Media Foundation made default writer.
- Works best with `Desktop Duplication`.

### Api Changes
- Added `IBitmapFrame.CopyTo` overload accepting `IntPtr`.
- Added `IFrameWrapper` interface. This is implemented by `MultiDisposeFrame`.
- Added `IImageProvider.EditorType`.