### PR TITLE
Move to .Net 4.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Dev builds can be unstable and should be used for testing purposes only.
 ## Build Notes
 
 - [Visual Studio 2017](https://visualstudio.com) or greater is required.
-- .Net Framework v4.6.1 is required.
+- .Net Framework v4.7.2 is required.
 - For detailed information, see [Building](https://mathewsachin.github.io/Captura/build).
 
 ## System Requirements
@@ -88,7 +88,7 @@ Dev builds can be unstable and should be used for testing purposes only.
 - **Desktop Duplication API** is only available on **Windows 8** and above.
 - 2 GHz CPU (Recommended).
 - 4 GB RAM (Recommended).
-- **.Net Framework v4.6.1** is required. You will be prompted to install if it is not already present on your system.
+- **.Net Framework v4.7.2** is required. You will be prompted to install if it is not already present on your system.
 - Using the **FFmpeg Intel QSV HEVC** encoder requires the processor to be **Skylake (6th generation)** or later.
 - For using `SharpAvi | Lagarith` codec, the Lagarith codec should be installed on your system and configured to use RGB mode with Null Frames disabled.
 

--- a/src/Captura.Console/App.config
+++ b/src/Captura.Console/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/Captura.Console/Captura.Console.csproj
+++ b/src/Captura.Console/Captura.Console.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Captura</RootNamespace>
     <AssemblyName>captura-cli</AssemblyName>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/Captura.Core/Captura.Core.csproj
+++ b/src/Captura.Core/Captura.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Base\Captura.Base.csproj" />

--- a/src/Captura.Hotkeys/Captura.Hotkeys.csproj
+++ b/src/Captura.Hotkeys/Captura.Hotkeys.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />

--- a/src/Captura.MouseKeyHook/Captura.MouseKeyHook.csproj
+++ b/src/Captura.MouseKeyHook/Captura.MouseKeyHook.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />

--- a/src/Captura.NAudio/Captura.NAudio.csproj
+++ b/src/Captura.NAudio/Captura.NAudio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Base\Captura.Base.csproj" />

--- a/src/Captura.SharpAvi/Captura.SharpAvi.csproj
+++ b/src/Captura.SharpAvi/Captura.SharpAvi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Base\Captura.Base.csproj" />

--- a/src/Captura.ViewCore/Captura.ViewCore.csproj
+++ b/src/Captura.ViewCore/Captura.ViewCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Core\Captura.Core.csproj" />

--- a/src/Captura.Windows/Captura.Windows.csproj
+++ b/src/Captura.Windows/Captura.Windows.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Captura</RootNamespace>
     <AssemblyName>captura</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -652,7 +652,14 @@
       <Version>1.0.0</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="Delete unused libs" AfterTargets="Build">
+    <ItemGroup>
+      <AvalonDockLibs Include="$(OutputPath)Xceed.Wpf.AvalonDock*.dll"/>
+    </ItemGroup>
+    
+    <Delete Files="@(AvalonDockLibs)" />
+    <Delete Files="$(OutputPath)Xceed.Wpf.DataGrid.dll" />
+  </Target>
   <Import Project="../PostBuild.targets" />
 </Project>

--- a/src/Captura/app.config
+++ b/src/Captura/app.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Captura.Tests</AssemblyName>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Moving to .Net 4.7.1 or above reduces the number of dependency DLLs which need to be distributed with Captura.

.Net 4.7.2 is available for Windows 7 SP1, Windows 8.1 and Windows 10 Anniversary update and above so that might not be a problem.

Number of dlls depended on by Captura is reduced by approx. 100 and 4 MB space is saved!

In addition, this pull-request remove dependencies on `Xceed.Wpf.AvalonDock` and `Xceed.Wpf.DataGrid` which saves another 5 libraries and 2.75 MB.

The only problem I could see with this is that Windows 10 users (who are still on Anniversary or Creators update) who could just download and run the earlier versions would now be prompted to install .Net 4.7.2.