### PR TITLE
Add Sentry for error tracking

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,8 @@ environment:
     secure: h5jOVeiDmjLnF3EotkOhBFJharX/9TWx6OWykiXn30pWSIfVjSvAaCJM1Y48zjXr
   git_key:
     secure: uhvhrrZd7L8MK4CrDGkM1A==
+  sentry_dsn:
+    secure: j7POciM8a2LOAiZy4uCyfAd8bMchteuAzdCA9Dx+18ACU4mOKMlPONxkdgUa7aOPxNN3WT4ShEBekrq2PBGr1w==
 
 install:
   - dotnet tool install -g Cake.Tool --version 0.32.1

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -19,10 +19,13 @@
    imgur_client_id      | Imgur Client Id
    yt_client_id         | YouTube Client Id
    yt_client_secret     | YouTube Client Secret
+   sentry_dsn           | Sentry DSN
 
    Imgur credentials are only required if you want to upload to Imgur. See [here](https://apidocs.imgur.com/) for more info.
 
    YouTube credentials are only required if you want to upload to YouTube. See [here](https://developers.google.com/youtube/registering_an_application) for more info.
+
+   Sentry DSN is used for error reporting. Visit https://sentry.io/ for more information.
 
 3. Download FFmpeg from within the app or from https://ffmpeg.zeranoe.com/builds/ or use a custom build.
 4. Now, you're good to go. You can build using Visual Studio or the [cake script](Cake.md).

--- a/docs/Privacy-Policy.md
+++ b/docs/Privacy-Policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy
+
+Effective from 22 July 2019.
+
+**TL;DR:** We **DON'T** collect your data except for the purpose of tracking errors which **DOES NOT** include any personal information which can be used to identify you.
+
+## For the App
+
+### Sentry
+The information sent to Sentry includes your Windows version, Captura version, .NET version and the error message.
+We're unable to identify individual users from that data.
+
+For more information on the data collected, see [Sentry's Privacy Policy](https://sentry.io/privacy/).
+
+### Uploading Services
+We provide links to the Privacy policies to the services supported by Captura.
+Please note that we don't collect your data when uploading to any of these services.
+
+#### Imgur
+The images you upload to Imgur are *public* and anyone with the link can view them.
+
+See [Imgur's Privacy Policy](https://imgur.com/privacy) for more information.
+
+#### Twitch
+[Twitch's Privacy Policy](https://www.twitch.tv/p/legal/privacy-policy).
+
+#### YouTube
+When uploading a video to YouTube, you have the option to make it Pulic, Private or Unlisted.
+
+Type     | Info
+---------|------------------------------
+Public   | Anyone can view
+Private  | Only you can view
+Unlisted | Anyone with the link can view
+
+## For the Website
+
+Our website does not use cookies or show ads.
+
+## On GitHub
+
+When you open an issue on GitHub, the information you provide is public and anyone can see it. Make sure to hide any sensitive information before posting.

--- a/licenses/Sentry.txt
+++ b/licenses/Sentry.txt
@@ -1,0 +1,12 @@
+Copyright (c) 2019 Sentry (https://sentry.io) and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+    3. Neither the name Sentry nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/Serilog.txt
+++ b/licenses/Serilog.txt
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/Captura.Base/Services/ILogger.cs
+++ b/src/Captura.Base/Services/ILogger.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Captura
+{
+    public interface ILogger : IDisposable
+    {
+        void Fatal(Exception E, string Message, params object[] Properties);
+
+        void Error(Exception E, string Message, params object[] Properties);
+
+        void Warning(Exception E, string Message, params object[] Properties);
+
+        void Information(Exception E, string Message, params object[] Properties);
+
+        void Debug(Exception E, string Message, params object[] Properties);
+
+        void Verbose(Exception E, string Message, params object[] Properties);
+    }
+}

--- a/src/Captura.Base/Video/IVideoSourceProvider.cs
+++ b/src/Captura.Base/Video/IVideoSourceProvider.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Captura.Models
 {
     public interface IVideoSourceProvider

--- a/src/Captura.Core/ApiKeys.cs
+++ b/src/Captura.Core/ApiKeys.cs
@@ -8,7 +8,7 @@ namespace Captura
     /// On Production builds, AppVeyor embeds Api Keys into the app.
     /// </summary>
     // ReSharper disable once ClassNeverInstantiated.Global
-    class ApiKeys : IImgurApiKeys, IYouTubeApiKeys
+    class ApiKeys : IImgurApiKeys, IYouTubeApiKeys, ISentryApiKeys
     {
         static string Get(string Key) => Environment.GetEnvironmentVariable(Key, EnvironmentVariableTarget.User) ?? "";
 
@@ -19,5 +19,7 @@ namespace Captura
         public string YouTubeClientId => Get("yt_client_id");
 
         public string YouTubeClientSecret => Get("yt_client_secret");
+
+        public string SentryDsn => Get("sentry_dsn");
     }
 }

--- a/src/Captura.Core/Captura.Core.csproj
+++ b/src/Captura.Core/Captura.Core.csproj
@@ -17,5 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Sentry.Serilog" Version="1.2.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Captura.Core/CoreModule.cs
+++ b/src/Captura.Core/CoreModule.cs
@@ -27,6 +27,8 @@ namespace Captura
             BindAudioSource(Binder);
             BindUpdateChecker(Binder);
 
+            Binder.Bind<ILogger, SentryLogger>();
+
             // Recent
             Binder.Bind<IRecentList, RecentListRepository>();
             Binder.Bind<IRecentItemSerializer, FileRecentSerializer>();
@@ -34,8 +36,7 @@ namespace Captura
 
             Binder.Bind<IImageUploader, ImgurUploader>();
             Binder.Bind<IIconSet, MaterialDesignIcons>();
-            Binder.Bind<IImgurApiKeys, ApiKeys>();
-            Binder.Bind<IYouTubeApiKeys, ApiKeys>();
+            BindApiKeys(Binder);
 
             Binder.BindSingleton<HotKeyManager>();
 
@@ -50,6 +51,13 @@ namespace Captura
             {
                 MfManager.Shutdown();
             }
+        }
+
+        public void BindApiKeys(IBinder Binder)
+        {
+            Binder.Bind<IImgurApiKeys, ApiKeys>();
+            Binder.Bind<IYouTubeApiKeys, ApiKeys>();
+            Binder.Bind<ISentryApiKeys, ApiKeys>();
         }
 
         static void BindImageWriters(IBinder Binder)

--- a/src/Captura.Core/Models/AroundMouseSourceProvider.cs
+++ b/src/Captura.Core/Models/AroundMouseSourceProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Screna;
-using System;
 using System.Drawing;
 using System.Text.RegularExpressions;
 

--- a/src/Captura.Core/Models/Sentry/ISentryApiKeys.cs
+++ b/src/Captura.Core/Models/Sentry/ISentryApiKeys.cs
@@ -1,0 +1,7 @@
+﻿namespace Captura
+{
+    interface ISentryApiKeys
+    {
+        string SentryDsn { get; }
+    }
+}

--- a/src/Captura.Core/Models/Sentry/SentryLogger.cs
+++ b/src/Captura.Core/Models/Sentry/SentryLogger.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Sentry;
+using Serilog;
+
+namespace Captura.Models
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    class SentryLogger : ILogger
+    {
+        public SentryLogger(ISentryApiKeys ApiKeys)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .MinimumLevel.Debug()
+                .WriteTo.Console()
+                .WriteTo.Sentry(M =>
+                {
+                    M.Dsn = new Dsn(ApiKeys.SentryDsn);
+                    M.AttachStacktrace = true;
+                })
+                .CreateLogger();
+        }
+
+        public void Fatal(Exception E, string Message, params object[] Properties)
+        {
+            Log.Fatal(E, Message, Properties);
+        }
+
+        public void Error(Exception E, string Message, params object[] Properties)
+        {
+            Log.Error(E, Message, Properties);
+        }
+
+        public void Warning(Exception E, string Message, params object[] Properties)
+        {
+            Log.Warning(E, Message, Properties);
+        }
+
+        public void Information(Exception E, string Message, params object[] Properties)
+        {
+            Log.Information(E, Message, Properties);
+        }
+
+        public void Debug(Exception E, string Message, params object[] Properties)
+        {
+            Log.Debug(E, Message, Properties);
+        }
+
+        public void Verbose(Exception E, string Message, params object[] Properties)
+        {
+            Log.Verbose(E, Message, Properties);
+        }
+
+        public void Dispose()
+        {
+            Log.CloseAndFlush();
+        }
+    }
+}

--- a/src/Captura.Core/Models/WebcamSourceProvider.cs
+++ b/src/Captura.Core/Models/WebcamSourceProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Captura.ViewModels;
+﻿using Captura.ViewModels;
 using Screna;
 
 namespace Captura.Models

--- a/src/Captura.Windows/Imaging/Direct2D/Direct2DEditor.cs
+++ b/src/Captura.Windows/Imaging/Direct2D/Direct2DEditor.cs
@@ -13,7 +13,6 @@ using BitmapInterpolationMode = SharpDX.Direct2D1.BitmapInterpolationMode;
 using Color = System.Drawing.Color;
 using PixelFormat = SharpDX.WIC.PixelFormat;
 using Point = System.Drawing.Point;
-using Rectangle = System.Drawing.Rectangle;
 using RectangleF = System.Drawing.RectangleF;
 
 namespace DesktopDuplication

--- a/src/Captura/App.xaml.cs
+++ b/src/Captura/App.xaml.cs
@@ -23,6 +23,9 @@ namespace Captura
 
             File.WriteAllText(Path.Combine(dir, $"{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.txt"), Args.Exception.ToString());
 
+            var logger = ServiceProvider.Get<ILogger>();
+            logger.Fatal(Args.Exception, nameof(App_OnDispatcherUnhandledException));
+
             Args.Handled = true;
 
             new ErrorWindow(Args.Exception, Args.Exception.Message).ShowDialog();
@@ -59,6 +62,9 @@ namespace Captura
             Directory.CreateDirectory(dir);
 
             File.WriteAllText(Path.Combine(dir, $"{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.txt"), E.ExceptionObject.ToString());
+
+            var logger = ServiceProvider.Get<ILogger>();
+            logger.Fatal(E.ExceptionObject as Exception, nameof(OnCurrentDomainOnUnhandledException));
 
             if (E.ExceptionObject is Exception e)
             {

--- a/src/Captura/Pages/VideoPage.xaml.cs
+++ b/src/Captura/Pages/VideoPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using Captura.ViewModels;
 
 namespace Captura
 {

--- a/src/Captura/Windows/MainWindow.xaml.cs
+++ b/src/Captura/Windows/MainWindow.xaml.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
-using Captura.ViewModels;
 
 namespace Captura
 {

--- a/src/Screna/VideoSourceProviders/VideoSourceProviderBase.cs
+++ b/src/Screna/VideoSourceProviders/VideoSourceProviderBase.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Captura.Models
 {
     public abstract class VideoSourceProviderBase : NotifyPropertyChanged, IVideoSourceProvider


### PR DESCRIPTION
Since many users are reporting similar errors which I'm not able to correctly reproduce on the systems I own, I think it would really help to automate the error reporting using [Sentry](https://sentry.io/).

I think this also needs an update to the Privacy Policy. I've prepared a draft in this pull-request and need suggestions for it.

### ToDo
- [ ] Option to opt-out of sending error information to Sentry.