### PR TITLE
Add FPS overlay

### DIFF
--- a/src/Captura.Core/Settings/Settings.cs
+++ b/src/Captura.Core/Settings/Settings.cs
@@ -86,6 +86,8 @@ namespace Captura
 
         public TextOverlaySettings Elapsed { get; set; } = new TextOverlaySettings();
 
+        public TextOverlaySettings FpsOverlay { get; set; } = new TextOverlaySettings();
+
         public ObservableCollection<CensorOverlaySettings> Censored { get; } = new ObservableCollection<CensorOverlaySettings>();
         
         public VisualSettings UI { get; } = new VisualSettings();

--- a/src/Captura.Core/ViewModels/RecordingModel.cs
+++ b/src/Captura.Core/ViewModels/RecordingModel.cs
@@ -501,6 +501,8 @@ namespace Captura.ViewModels
 
             yield return new ElapsedOverlay(Settings.Elapsed, () => _timerModel.TimeSpan);
 
+            yield return new FpsOverlay(Settings.FpsOverlay);
+
             // Text Overlays
             foreach (var overlay in Settings.TextOverlays)
             {

--- a/src/Captura/Pages/VideoPage.xaml
+++ b/src/Captura/Pages/VideoPage.xaml
@@ -49,6 +49,12 @@
                 </captura:ModernToggleButton>
             </StackPanel>
 
+            <CheckBox IsChecked="{Binding Settings.FpsOverlay.Display}"
+                      Margin="0,2">
+                <TextBlock TextWrapping="Wrap"
+                           Text="Show FPS Overlay"/>
+            </CheckBox>
+
             <Grid Margin="0,0,0,5"
                   IsEnabled="{Binding ViewConditions.IsEnabled.Value, Source={StaticResource ServiceLocator}}">
                 <Grid.ColumnDefinitions>

--- a/src/Captura/Windows/OverlayWindow.xaml
+++ b/src/Captura/Windows/OverlayWindow.xaml
@@ -36,6 +36,12 @@
                                                   DataContext="{Binding Settings.Elapsed}"
                                                   DockPanel.Dock="Bottom"/>
             </TabItem>
+            <TabItem Header="Fps"
+                     DataContext="{Binding AboutViewModel, Source={StaticResource ServiceLocator}}">
+                <local:TextOverlaySettingsControl Margin="5"
+                                                  DataContext="{Binding Settings.FpsOverlay}"
+                                                  DockPanel.Dock="Bottom"/>
+            </TabItem>
             <TabItem Header="Censor">
                 <Frame Source="../Pages/CensorOverlaysPage.xaml"/>
             </TabItem>

--- a/src/Captura/Windows/OverlayWindow.xaml.cs
+++ b/src/Captura/Windows/OverlayWindow.xaml.cs
@@ -313,6 +313,9 @@ namespace Captura
             var elapsed = Text(settings.Elapsed, "00:00:00");
             AddToGrid(elapsed, false);
 
+            var fps = Text(settings.FpsOverlay, "FPS");
+            AddToGrid(fps, false);
+
             var textOverlayVm = ServiceProvider.Get<CustomOverlaysViewModel>();
 
             UpdateTextOverlays(textOverlayVm.Collection);

--- a/src/Screna/Overlays/FpsOverlay.cs
+++ b/src/Screna/Overlays/FpsOverlay.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Captura.Models
+{
+    public class FpsOverlay : TextOverlay
+    {
+        readonly Stopwatch _sw = new Stopwatch();
+        int _frames;
+        readonly TimeSpan _diff = TimeSpan.FromSeconds(1);
+        int _fps;
+
+        public FpsOverlay(TextOverlaySettings OverlaySettings) : base(OverlaySettings)
+        {
+        }
+
+        protected override string GetText()
+        {
+            if (!_sw.IsRunning)
+            {
+                _sw.Start();
+
+                return "-";
+            }
+
+            ++_frames;
+
+            if (_sw.Elapsed > _diff)
+            {
+                _fps = (int)Math.Round(_frames / _sw.Elapsed.TotalSeconds);
+                _frames = 0;
+
+                _sw.Restart();
+            }
+
+            return _fps.ToString();
+        }
+    }
+}


### PR DESCRIPTION
This overlay is present only in the recorded video and not shown on screen.
It can be seen in the preview.