### PR TITLE
Single Instance

### DIFF
--- a/src/Captura/App.xaml.cs
+++ b/src/Captura/App.xaml.cs
@@ -13,6 +13,13 @@ namespace Captura
 {
     public partial class App
     {
+        public App()
+        {
+            SingleInstanceManager.SingleInstanceCheck();
+
+            ShowSplashScreen();
+        }
+
         public static CmdOptions CmdOptions { get; private set; }
         
         void App_OnDispatcherUnhandledException(object Sender, DispatcherUnhandledExceptionEventArgs Args)
@@ -26,6 +33,12 @@ namespace Captura
             Args.Handled = true;
 
             new ErrorWindow(Args.Exception, Args.Exception.Message).ShowDialog();
+        }
+
+        void ShowSplashScreen()
+        {
+            var splashScreen = new SplashScreen("Images/Logo.png");
+            splashScreen.Show(true);
         }
 
         void Application_Startup(object Sender, StartupEventArgs Args)

--- a/src/Captura/App.xaml.cs
+++ b/src/Captura/App.xaml.cs
@@ -17,6 +17,7 @@ namespace Captura
         {
             SingleInstanceManager.SingleInstanceCheck();
 
+            // Splash Screen should be created manually and after single-instance is checked
             ShowSplashScreen();
         }
 

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -12,7 +12,7 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <SplashScreen Include="Images\Logo.png" />
+    <Resource Include="Images\Logo.png" />
     <Resource Include="Images\record.ico" />
     <Resource Include="Images\Captura.ico" />
     <Resource Include="Images\pause.ico" />

--- a/src/Captura/Models/SingleInstanceManager.cs
+++ b/src/Captura/Models/SingleInstanceManager.cs
@@ -6,9 +6,15 @@ namespace Captura.Models
 {
     public static class SingleInstanceManager
     {
+        // ReSharper disable once NotAccessedField.Local
         static Mutex _mutex;
+        // ReSharper disable once NotAccessedField.Local
+        static Task _task;
 
+        // Mutex allows us to know whether another instance is already open
         const string MutexId = "captura-mutex-304bae7c-e520-4bfe-a308-c99476062091";
+
+        // EventWaitHandle allows us to communicate to a already running instance
         const string EventWaitHandleId = "captura-wait-304bae7c-e520-4bfe-a308-c99476062091";
 
         public static void SingleInstanceCheck()
@@ -17,15 +23,14 @@ namespace Captura.Models
 
             if (!createdNew)
             {
+                // Bring the already running instance to the foreground
                 var handle = CreateWaitHandle();
-
                 handle.Set();
 
+                // Exit duplicate instance
                 Environment.Exit(0);
             }
         }
-
-        static Task _task;
 
         static EventWaitHandle CreateWaitHandle()
         {
@@ -34,6 +39,7 @@ namespace Captura.Models
 
         public static void StartListening(Action Callback)
         {
+            // First instance listens for events from other instances in a loop
             _task = Task.Run(() =>
             {
                 var waitHandle = CreateWaitHandle();
@@ -42,6 +48,7 @@ namespace Captura.Models
                 {
                     waitHandle.WaitOne();
 
+                    // Callback should bring first instance to foreground
                     Callback.Invoke();
                 }
             });

--- a/src/Captura/Models/SingleInstanceManager.cs
+++ b/src/Captura/Models/SingleInstanceManager.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Captura.Models
+{
+    public static class SingleInstanceManager
+    {
+        static Mutex _mutex;
+
+        const string MutexId = "captura-mutex-304bae7c-e520-4bfe-a308-c99476062091";
+        const string EventWaitHandleId = "captura-wait-304bae7c-e520-4bfe-a308-c99476062091";
+
+        public static void SingleInstanceCheck()
+        {
+            _mutex = new Mutex(true, MutexId, out var createdNew);
+
+            if (!createdNew)
+            {
+                var handle = CreateWaitHandle();
+
+                handle.Set();
+
+                Environment.Exit(0);
+            }
+        }
+
+        static Task _task;
+
+        static EventWaitHandle CreateWaitHandle()
+        {
+            return new EventWaitHandle(false, EventResetMode.AutoReset, EventWaitHandleId);
+        }
+
+        public static void StartListening(Action Callback)
+        {
+            _task = Task.Run(() =>
+            {
+                var waitHandle = CreateWaitHandle();
+
+                while (true)
+                {
+                    waitHandle.WaitOne();
+
+                    Callback.Invoke();
+                }
+            });
+        }
+    }
+}

--- a/src/Captura/Windows/MainWindow.xaml.cs
+++ b/src/Captura/Windows/MainWindow.xaml.cs
@@ -45,6 +45,7 @@ namespace Captura
                     Args.Cancel = true;
             };
 
+            // Register to bring this instance to foreground when other instances are launched.
             SingleInstanceManager.StartListening(WakeApp);
         }
 

--- a/src/Captura/Windows/MainWindow.xaml.cs
+++ b/src/Captura/Windows/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
+using Captura.Models;
 
 namespace Captura
 {
@@ -43,6 +44,21 @@ namespace Captura
                 if (!TryExit())
                     Args.Cancel = true;
             };
+
+            SingleInstanceManager.StartListening(WakeApp);
+        }
+
+        void WakeApp()
+        {
+            Dispatcher.Invoke(() =>
+            {
+                if (WindowState == WindowState.Minimized)
+                {
+                    WindowState = WindowState.Normal;
+                }
+
+                Activate();
+            });
         }
 
         void RepositionWindowIfOutside()


### PR DESCRIPTION
If you start the app again, the app won't launch again, the already running instance gains focus.

A `Mutex` is used to ensure that only a single instance runs, and an `EventWaitHandle` is used to wake the single instance when you try to launch another.