### PR TITLE
Show repeat counter setting

### DIFF
--- a/src/Captura.MouseKeyHook/KeyOverlay.cs
+++ b/src/Captura.MouseKeyHook/KeyOverlay.cs
@@ -164,7 +164,7 @@ namespace Captura.Models
             {
                 if (_records.Last?.Display == display)
                 {
-                    _records.Last = new RepeatKeyRecord(record);
+                    _records.Last = new RepeatKeyRecord(record, _settings);
                 }
                 else if (_records.Last is RepeatKeyRecord repeat && repeat.Repeated.Display == display)
                 {
@@ -218,7 +218,7 @@ namespace Captura.Models
             }
             else if (_records.Last is KeyRecord keyRecord && keyRecord.Display == display)
             {
-                _records.Last = new RepeatKeyRecord(record);
+                _records.Last = new RepeatKeyRecord(record, _settings);
             }
             else if (_records.Last is RepeatKeyRecord repeatRecord && repeatRecord.Repeated.Display == display)
             {

--- a/src/Captura.MouseKeyHook/KeyRecord/RepeatKeyRecord.cs
+++ b/src/Captura.MouseKeyHook/KeyRecord/RepeatKeyRecord.cs
@@ -4,9 +4,12 @@ namespace Captura.Models
 {
     class RepeatKeyRecord : IKeyRecord
     {
-        public RepeatKeyRecord(KeyRecord Repeated)
+        readonly KeystrokesSettings _settings;
+
+        public RepeatKeyRecord(KeyRecord Repeated, KeystrokesSettings Settings)
         {
             this.Repeated = Repeated;
+            _settings = Settings;
 
             Increment();
         }
@@ -28,6 +31,8 @@ namespace Captura.Models
             TimeStamp = DateTime.Now;
         }
 
-        public string Display => $"{Repeated} x {Repeat}";
+        public string Display => _settings.ShowRepeatCounter
+            ? $"{Repeated} x {Repeat}"
+            : Repeated.ToString();
     }
 }

--- a/src/Captura.MouseKeyHook/Models/KeystrokesSettings.cs
+++ b/src/Captura.MouseKeyHook/Models/KeystrokesSettings.cs
@@ -28,6 +28,12 @@ namespace Captura
             set => Set(value);
         }
 
+        public bool ShowRepeatCounter
+        {
+            get => Get(true);
+            set => Set(value);
+        }
+
         public string KeymapName
         {
             get => Get(KeymapViewModel.DefaultKeymapFileName);

--- a/src/Captura/Pages/KeystrokesPage.xaml
+++ b/src/Captura/Pages/KeystrokesPage.xaml
@@ -82,6 +82,11 @@
                                         Grid.Column="1"
                                         Margin="0,5"/>
                 </Grid>
+
+                <CheckBox Content="Show Repeat Counter"
+                          IsChecked="{Binding ShowRepeatCounter, Mode=TwoWay}"
+                          Margin="0,3"
+                          Visibility="{Binding SeparateTextFile, Converter={StaticResource NegatingConverter}}"/>
             </StackPanel>
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
Requested in #485 

On the keystroke settings page, a checkbox has been added which can be unchecked to disable repeated key presses shown like `Ctrl x3`.