### PR TITLE
Github workflows - Markdown lint tool

### DIFF
--- a/.github/workflows/.markdownlint.rb
+++ b/.github/workflows/.markdownlint.rb
@@ -1,0 +1,10 @@
+all
+#Allow ? in headers - used in FAQ
+rule 'MD026', :punctuation => '.,;:!'
+#Allow ordered lists by 123
+rule 'MD029', :style => 'ordered'
+#Allow long lines in tables
+rule 'MD013', :tables  => false
+#Allow inline HTML - using <br> for multiple lines in tables
+exclude_rule 'MD033'
+exclude_rule 'MD023' #False positives

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: lint
+
+on:
+  push:
+    branches: master
+  pull_request:
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest  
+    
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+    - name: Lint documentation markdown files    
+      run: |
+        gem install mdl
+        mdl docs/ -s '.github/workflows/.markdownlint.rb'

--- a/docs/Acknowledgements.md
+++ b/docs/Acknowledgements.md
@@ -3,103 +3,134 @@
 ## Tools and Services
 
 ### Resharper
+
 Kudos to Jetbrains for providing open-source license for [Resharper Ultimate](https://www.jetbrains.com/resharper/).
-Resharper makes development much intutive and easier. You should really check it out.
-If you become a regular contributor to Captura, you may request for the Resharper license.
+Resharper makes development much intutive and easier. You should really check
+it out.If you become a regular contributor to Captura, you may request for the
+Resharper license.
 
 ### Crowdin
-Great thanks to [Crowdin](https://crowdin.com/) for providing open-source license.
-The translation for Captura is done on Crowdin.
-Also, thanks to everyone who contributed the translations.
+
+Great thanks to [Crowdin](https://crowdin.com/) for providing open-source
+license. The translation for Captura is done on Crowdin. Also, thanks to
+everyone who contributed the translations.
 
 ### AppVeyor
-We use [AppVeyor](https://www.appveyor.com/) for Continuous Integration. The build and release processes run there.
-It's free for open-source projects and especially good for .NET projects.
+
+We use [AppVeyor](https://www.appveyor.com/) for Continuous Integration.
+The build and release processes run there. It's free for open-source projects
+and especially good for .NET projects.
 
 ### GitHub
-I can't thank [GitHub](https://github.com/) enough for being an open platform for developers.
-The source code and the website are both hosted here.
+
+I can't thank [GitHub](https://github.com/) enough for being an open
+platform for developers. The source code and the website are both hosted here.
 
 ### Cake Build
-[Cake](https://cakebuild.net/) allows us to write our build scripts in C# instead of using other scripting languages.
+
+[Cake](https://cakebuild.net/) allows us to write our build scripts in C#
+instead of using other scripting languages.
 
 ### Visual Studio Community
-[Visual Studio IDE](https://visualstudio.microsoft.com/) for free for open-source and small organisations.
+
+[Visual Studio IDE](https://visualstudio.microsoft.com/) for free for
+open-source and small organisations.
 
 ### Visual Studio Code
-[Visual Studio Code](https://code.visualstudio.com) is an open-source text editor used to build the website and write the documentation.
+
+[Visual Studio Code](https://code.visualstudio.com) is an open-source text
+editor used to build the website and write the documentation.
 
 ### Inno Setup
+
 Setup files for Captura are built using [Inno Setup](http://www.jrsoftware.org/isinfo.php).
 
 ## Libraries
 
 ### CommandLineParser
+
 [GitHub](https://github.com/commandlineparser/commandline/) -
 [MIT License](https://github.com/commandlineparser/commandline/blob/master/License.md)
 
-```
+```nuget
 NuGet Install CommandLineParser
 ```
 
 ### CroppingAdorner
-[CodeProject Article](https://www.codeproject.com/Articles/23158/A-Photoshop-like-Cropping-Adorner-for-WPF) -
+
+[CodeProject Article](https://www.codeproject.com/Articles/23158/A-Photoshop-like-Cropping-Adorner-for-WPF)
 [Code Project Open License (CPOL)](https://www.codeproject.com/info/cpol10.aspx)
 
 ### DirectShowLib
+
 [SourceForge](http://directshownet.sourceforge.net/)
 
 ### FFmpeg
+
 [Website](https://ffmpeg.org/)
 
 ### MouseKeyHook
+
 [GitHub](https://github.com/gmamaladze/globalmousekeyhook) -
 [MIT License](https://github.com/gmamaladze/globalmousekeyhook/blob/vNext/LICENSE.txt)
 
-```
+```nuget
 nuget install MouseKeyHook
 ```
 
 ### MUI.Extended.Toolkit
+
 [GitHub](https://github.com/samoatesgames/mui.extended.toolkit) -
 [MIT License](https://github.com/samoatesgames/mui.extended.toolkit/blob/master/LICENSE)
 
 ### MUI
+
 [GitHub](https://github.com/firstfloorsoftware/mui) -
 [MS-PL](https://github.com/firstfloorsoftware/mui/blob/master/LICENSE.md)
 
 ### NAudio
+
 [GitHub](https://github.com/naudio/NAudio) -
 [MS-PL](https://github.com/naudio/NAudio/blob/master/license.txt)
 
 ### Newtonsoft.Json
+
 [Website](https://www.newtonsoft.com/json) -
 [GitHub](https://github.com/JamesNK/Newtonsoft.Json) -
 [MIT License](https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)
 
 ### Ooki.Dialogs
+
 [Website](http://www.ookii.org/software/dialogs/)
 
 ### ReactiveProperty
+
 [GitHub](https://github.com/runceel/ReactiveProperty)
 
 ### ScreenToGif
+
 [Website](https://www.screentogif.com/)
 
 ### SharpAvi
+
 [GitHub](https://github.com/baSSiLL/SharpAvi)
 
 ### SharpDX
+
 [GitHub](https://github.com/sharpdx/SharpDX)
 
 ### WPFNotifyIcon
+
 [Website](http://www.hardcodet.net/wpf-notifyicon)
 
 ### WpfToolkit
+
 [GitHub](https://github.com/xceedsoftware/wpftoolkit)
 
 ### Media Foundation .NET
+
 [SourceForge](http://mfnet.sourceforge.net/)
 
 ### ReactiveX
+
 [GitHub](https://github.com/dotnet/reactive)

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -3,26 +3,36 @@
 ## Setting up locally
 
 ### Prerequisites
+
 - Visual Studio 2019 or newer with .NET desktop development workload.
 - .Net Core 2.1 or greater
-- Cake tool  
+- Cake tool
   Install: `dotnet tool install -g Cake.Tool --version 0.32.1`
 - Some features have other specific requirements, see [here](https://mathewsachin.github.io/Captura/sys-req).
 
 ### Steps
-1. Clone  
+
+1. Clone
    `git clone https://github.com/MathewSachin/Captura.git`
-2. Setup Api Keys. These are loaded from environment variables during development and embedded into the app on production builds.
-   
+
+2. Setup Api Keys. These are loaded from environment variables during
+   development and embedded into the app on production builds.
+
    Environment Variable | Description
    ---------------------|-------------
    imgur_client_id      | Imgur Client Id
    yt_client_id         | YouTube Client Id
    yt_client_secret     | YouTube Client Secret
 
-   Imgur credentials are only required if you want to upload to Imgur. See [here](https://apidocs.imgur.com/) for more info.
+   Imgur credentials are only required if you want to upload to Imgur.
+   See [here](https://apidocs.imgur.com/) for more info.
 
-   YouTube credentials are only required if you want to upload to YouTube. See [here](https://developers.google.com/youtube/registering_an_application) for more info.
+   YouTube credentials are only required if you want to upload to YouTube.
+   See [here](https://developers.google.com/youtube/registering_an_application)
+   for more info.
 
-3. Download FFmpeg from within the app or from https://ffmpeg.zeranoe.com/builds/ or use a custom build.
-4. Now, you're good to go. You can build using Visual Studio or the [cake script](Cake.md).
+3. Download FFmpeg from within the app or from
+   <https://ffmpeg.zeranoe.com/builds/> or use a custom build.
+
+4. Now, you're good to go. You can build using Visual Studio or the
+   [cake script](Cake.md).

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,14 +1,16 @@
 # Continuous Integration
 
 We use [Appveyor](https://www.appveyor.com/) for CI.
-When a commit is pushed to the GitHub repository, AppVeyor clones the repo and builds and tests it using the Cake build script.
-If it is a tag build, the release is deployed to GitHub Releases as a draft and to Chocolatey.
+When a commit is pushed to the GitHub repository, AppVeyor clones the repo
+and builds and tests it using the Cake build script.If it is a tag build,
+the release is deployed to GitHub Releases as a draft and to Chocolatey.
 
-### Getting dev builds
+## Getting dev builds
 
 > Dev builds can be unstable and should be used for testing purposes only.
 
-1. Go to [AppVeyor project](https://ci.appveyor.com/project/MathewSachin/Captura/branch/master) page.
+1. Go to [AppVeyor project](https://ci.appveyor.com/project/MathewSachin/Captura/branch/master)
+   page.
 
 2. Select Build Configuration: **Debug** or **Release**.
 

--- a/docs/Cake.md
+++ b/docs/Cake.md
@@ -1,25 +1,27 @@
 # Cake build script
 
-### Installing Cake
+## Installing Cake
+
 .NET Core 2.1 is required.
 
-```
+```dotnet
 dotnet tool install -g Cake.Tool --version 0.32.1
 ```
 
-### Running the build script
-```
+## Running the build script
+
+```dotnet
 dotnet-cake
 ```
 
-### Arguments
+## Arguments
 
 Option         | Description
 ---------------|--------------
--build_version | Build version. Should be like v9.0.0 for stable and CI builds and like v9.0.0-beta3 for prerelease builds. AssemblyInfo.cs files are updated based on this value during build.
+-build_version | Build version. Should be like v9.0.0 for stable and CI builds <br> and like v9.0.0-beta3 for prerelease builds. AssemblyInfo.csfiles <br> are updated based on this value during build.
 -configuration | Configuration: Release or Debug
 -target        | The Task to run in the build script. See build.cake
 
-```
+```dotnet
 dotnet-cake --target=CI --configuration=Release
 ```

--- a/docs/Changelogs/v8.0.0.md
+++ b/docs/Changelogs/v8.0.0.md
@@ -2,37 +2,53 @@
 
 > This changelog is incomplete.
 
-### Audio / Video Sources
+## Audio / Video Sources
+
 - Stop Window capture when Window is closed.
 - **Fix:** Mouse cursor position is wrong after moving region selector.
 - **Fix:** Unable to resize Region Selector after stopping recording.
 - Desktop Duplication is supported with Variable Frame Rate Gif.
-- **Fix:** Desktop Duplication recording does not crash when Screen enters non-recordable mode. e.g. Sign-in screen.
+
+- **Fix:** Desktop Duplication recording does not crash when Screen enters
+  non-recordable mode. e.g. Sign-in screen.
+
 - Added an option to playback recorded audio in real-time in Config | Extras.
 - Record and ScreenShot buttons on Region Selector.
-- Added Window picker and Screen picker which prompt for selector on starting recording or taking screenshot.
+
+- Added Window picker and Screen picker which prompt for selector on starting
+  recording or taking screenshot.
+
 - More than 2 audio sources can be simultaneously recorded.
-- Audio sources can be changed during recording. A checkbox next to the Audio heading determines whether audio will be recorded.
+
+- Audio sources can be changed during recording. A checkbox next to the Audio
+  heading determines whether audio will be recorded.
+
 - Shows Error Message when bass.dll or bassmix.dll is not present.
 - Hide when Recording option is configured on Region Selector itself.
 - Refresh retains selected Audio/Video sources/codecs and Webcam.
 - Basic drawing support in Region Selector.
 
-### Preview
+## Preview
+
 - Added option to Preview while recording.
 - Supports full screen view.
 
-### Overlays
+## Overlays
+
 - Overlays are now configured on a separate window.
 - Overlays can be positioned by dragging boxes over a Background on the window.
 - Separate colors for Right and Middle mouse click overlays.
 - Support for custom image overlays.
 - Overlay customization from UI is used in Console.
-- Option to display Mouse Pointer Overlay to make easier to track Mouse Pointer.
+
+- Option to display Mouse Pointer Overlay to make easier to track Mouse
+  Pointer.
+
 - Added minimal mouse click animation.
 - Elapsed is separated from TextOverlays and can be toggled from Main View.
 
-### FFmpeg
+## FFmpeg
+
 - Option to resize FFmpeg output video size.
 - FFmpeg Log maintains multiple logs.
 - FFmpeg Log copies complete output to clipboard.
@@ -40,28 +56,35 @@
 - Increased FFmpeg thread_queue_size
 - Ensure previous frame is written when writing asynchronously.
 
-### Hotkey Window
-Separate window to manage hotkeys with option to add, delete or edit action and keys.
+## Hotkey Window
 
-### Image Editor
+Separate window to manage hotkeys with option to add, delete or edit action
+and keys.
+
+## Image Editor
+
 - Added a minimal image editor.
 - Added a new ScreenShot target: Editor.
 
-### Image Cropper
+## Image Cropper
+
 Added option to crop images.
 
-### Audio / Video Trimmer
+## Audio / Video Trimmer
+
 Added option to trim Audio and Video.
 
-### Translation
+## Translation
+
 Added new translations:
 
 - Japanese
 - Chinese (Simplified)
 - Chinese (Traditional)
 
-### Other
-- **Fix:**captura shot failing for fullscreen screenshots.
+## Other
+
+- **Fix:** captura shot failing for fullscreen screenshots.
 - **Fix:** Main window webcam preview position on high DPI.
 - Duration is considered after Start Delay has elapsed.
 - Duration and Start Delay are stored in Settings.
@@ -76,5 +99,10 @@ Added new translations:
 - Display Licenses in a Window.
 - Notification Stack
 - Added an Exception Dialog.
-- Stop Recorder when Frames are not being writen. This happens when either the FrameRate is too high or a codec is slow. No of frames to be written are checked with a maximum value to determine whether to stop recording. This helps prevent crash from 100% RAM usage and causing the system to hang.
+
+- Stop Recorder when Frames are not being writen. This happens when either the
+  FrameRate is too high or a codec is slow. No of frames to be written are
+  checked with a maximum value to determine whether to stop recording. This
+  helps prevent crash from 100% RAM usage and causing the system to hang.
+
 - Ability to delete uploaded images from Imgur

--- a/docs/Changelogs/v9.0.0.md
+++ b/docs/Changelogs/v9.0.0.md
@@ -7,9 +7,16 @@
 - Fallback to NAudio for audio when BASS is not available.
 - Update check in footer.
 - Open Webcam preview window by clicking on small preview.
-- **Fix:** Recording failing due to `System can't keep up with the Recording. Frames are not being written. Retry again or try with a smaller region, lower Frame Rate or another Codec.`
+
+- **Fix:** Recording failing due to `System can't keep up with the Recording.
+  Frames are not being written. Retry again or try with a smaller region,
+  lower Frame Rate or another Codec.`
+
 - Replaced the Gif encoder with FFmpeg Gif (Post-Processing) encoder.
-- Discard writer renamed to Preview Only and automatically shows Preview window on starting recording.
+
+- Discard writer renamed to Preview Only and automatically shows Preview window
+  on starting recording.
+
 - Use system confirmation dialog when deleting from recent list.
 - Added YouTube upload feature. Can be used from recent list context menu.
 - Remove notifications when notification stack hides.
@@ -27,6 +34,9 @@
 - **Fix:** Streaming FrameRate was always set to 10.
 - Added Webcam only mode.
 - Settings, Codecs folders in AppDir for portability.
-- Support `%CAPTURA_PATH%` to point to app directory in FFmpeg, Output and Settings paths.
+
+- Support `%CAPTURA_PATH%` to point to app directory in FFmpeg, Output and
+  Settings paths.
+
 - Change `Minimize on Capture Start` to minimize to tray.
 - Show a simpler Error Window on Exceptions.

--- a/docs/Choco.md
+++ b/docs/Choco.md
@@ -1,7 +1,10 @@
 # Chocolatey
-Chocolatey package is created using the Cake build script and deployed on tag builds by AppVeyor.
 
-### Installation
-```
+Chocolatey package is created using the Cake build script and deployed on
+tag builds by AppVeyor.
+
+## Installation
+
+```choco
 choco install captura -y
 ```

--- a/docs/Cmdline/Arg-Source.md
+++ b/docs/Cmdline/Arg-Source.md
@@ -1,29 +1,34 @@
 # Using the source Argument
 
 ## Desktop
+
 Use the `desktop` parameter to capture the entire Desktop **(Default)**.
 Works with both `captura-cli start` and `captura-cli shot`.
 This is the default option, so is as good as not using this option.
 
 e.g.
 
-```
+```powershell
 captura-cli start --source desktop
 ```
 
 ## Region
-Use Left, Top, Width and Height resp. as comma separated values to represent the region to capture.
-Works with both `captura-cli start` and `captura-cli shot`.
-The dimensions of the region must be even. If not, they are decreased by 1 as required.
+
+Use Left, Top, Width and Height resp. as comma separated values to
+represent the region to capture. Works with both `captura-cli start`
+and `captura-cli shot`. The dimensions of the region must be even.
+If not, they are decreased by 1 as required.
 
 e.g.
 
-```
+```powershell
 captura-cli shot --source 100,100,300,400
 ```
 
 ## Screen
-Use `screen:<index>` as the argument. `index` is a zero-based index identifying the screen.
+
+Use `screen:<index>` as the argument. `index` is a zero-based index
+identifying the screen.
 
 Works with both `captura-cli start` and `captura-cli shot`.
 
@@ -31,11 +36,12 @@ You can use `captura-cli list` to check screen indices.
 
 e.g.
 
-```
+```powershell
 captura-cli start --source screen:1
 ```
 
 ## No Video
+
 Use `none` for No Video.
 
 Available only with `captura-cli start`.
@@ -44,18 +50,21 @@ Can be used for audio only recording.
 
 e.g. Record only the speaker output.
 
-```
+```powershell
 captura-cli start --source none --speaker 0
 ```
 
 ## Window
+
 Use `win:<hWnd>` as the argument. `hWnd` is handle of the window.
 
-When using with `captura-cli start`, the window handle must be in the `captura-cli list` output.
+When using with `captura-cli start`, the window handle must be
+in the `captura-cli list` output.
 
 You can use `captura-cli list` to check visible window handles.
 
 ## Webcam
+
 Use `webcam` as the argument to capture only the webcam.
 Can only work with `captura-cli start`.
 
@@ -64,6 +73,6 @@ You can use `captura-cli list` to check available webcams.
 
 e.g.
 
-```
+```powershell
 captura-cli start --source webcam --webcam 0
 ```

--- a/docs/Cmdline/README.md
+++ b/docs/Cmdline/README.md
@@ -5,21 +5,29 @@ Project      | Executable
 UI           | captura.exe
 Command-line | captura-cli.exe
 
-We use the [CommandLineParser](https://nuget.org/packages/CommandLineParser) NuGet package.
+We use the [CommandLineParser](https://nuget.org/packages/CommandLineParser)
+NuGet package.
 
-The console projects uses default settings with a few modifications and does not save settings.
+The console projects uses default settings with a few modifications and does
+not save settings.
 
 > Command-line support is not very stable. Please report any bugs you find.
 
-### Why a separate Console app?
+## Why a separate Console app?
+
 There are many issues related to using a WPF application as a console app.
 
-- WPF applications don't block the console. So, we cannot use it for scenarios like wait till capture is completed.
+- WPF applications don't block the console. So, we cannot use it for scenarios
+  like wait till capture is completed.
+
 - Writing to console does not work by default
-- If `AttachConsole` is used, the written content interferes with console prompt.
+
+- If `AttachConsole` is used, the written content interferes with console
+  prompt.
+
 - And more ...
 
-### Command-line parameters for UI version
+## Command-line parameters for UI version
 
 Argument     | Description
 -------------|----------------------------------
@@ -31,11 +39,11 @@ Argument     | Description
 
 e.g. Start captura minimized to tray
 
-```
+```powershell
 captura --tray
 ```
 
-### Implemented Verbs
+## Implemented Verbs
 
 - [list](Verb-List.md)
   List available Screens, Windows, Audio Sources, Webcams, etc.
@@ -43,9 +51,9 @@ captura --tray
   Start a Recording
 - [shot](Verb-Shot.md)
   Take a ScreenShot
-- [ffmpeg](Verb-FFmpeg.md)  
+- [ffmpeg](Verb-FFmpeg.md)
   Allows installation of ffmpeg from command-line.
-- help  
+- help
   Provides help on using the console app.
-- version  
+- version
   Prints the version of the console app.

--- a/docs/Cmdline/Verb-FFmpeg.md
+++ b/docs/Cmdline/Verb-FFmpeg.md
@@ -1,8 +1,9 @@
 # Verb: FFmpeg
+
 Can be used to install FFmpeg
 
 e.g. Install FFmpeg to Codecs directory
 
-```
+```powershell
 captura-cli ffmpeg --install Codecs
 ```

--- a/docs/Cmdline/Verb-List.md
+++ b/docs/Cmdline/Verb-List.md
@@ -1,4 +1,5 @@
 # Verb: list
+
 Displays the following information:
 
 - Version
@@ -12,6 +13,6 @@ Displays the following information:
 - Available Microphones
 - Available Speaker output sources
 
-```
+```powershell
 captura list
 ```

--- a/docs/Cmdline/Verb-Shot.md
+++ b/docs/Cmdline/Verb-Shot.md
@@ -1,4 +1,5 @@
 # Verb: shot
+
 Takes a screenshot
 
 Argument         | Description
@@ -9,6 +10,6 @@ Argument         | Description
 
 e.g. Take a screenshot containing cursor.
 
-```
+```dotnet
 captura-cli shot --cursor
 ```

--- a/docs/Cmdline/Verb-Start.md
+++ b/docs/Cmdline/Verb-Start.md
@@ -1,4 +1,5 @@
 # Verb: start
+
 Starts Recording.
 
 There are two modes.
@@ -14,20 +15,18 @@ Argument              | Description
 `--delay`             | Delay before starting recording (in ms)
 `-t` or `--length`    | Length of recording (in s)
 `--source`            | The source to record from. See [here](Arg-Source.md).
-`--mic`               | The microphone index to use. (-1 = none (Default)) (0 is first device).
-`--speaker`           | The speaker output index to use. (-1 = none (Default)) (0 is first device).
-`--webcam`            | Webcam to use. (-1 = none (Default)) (0 is first webcam).
+`--mic`               | The microphone index to use. (-1 = none (Default))<br>(0 is first device).
+`--speaker`           | The speaker output index to use. (-1 = none (Default))<br>(0 is first device).
+`--webcam`            | Webcam to use. (-1 = none (Default))<br>(0 is first webcam).
 `-r` or `--framerate` | Frame Rate (Default is 10).
 `--encoder`           | The video encoder to use. See below.
 `--vq`                | Video Quality (1 to 100) (Default is 70).
 `--aq`                | Audio Quality (1 to 100) (Default is 50).
 `-f` or `--file`      | Output file path.
 `-y`                  | Overwrite existing file.
-`--replay`            | Replay recording. Specify duration in seconds as parameter. e.g. `--replay 20`.
+`--replay`            | Replay recording. Specify duration in seconds as<br>parameter. e.g. `--replay 20`.<br>e.g. Record 10 seconds with cursor and keystrokes and audio from first speaker output.
 
-e.g. Record 10 seconds with cursor and keystrokes and audio from first speaker output.
-
-```
+```powershell
 captura-cli start --length 10 --cursor --keys --speaker=0
 ```
 
@@ -36,56 +35,63 @@ captura-cli start --length 10 --cursor --keys --speaker=0
 By default, SharpAvi Motion JPEG encoder is used.
 
 ### SharpAvi
-Use `sharpavi:<index>` as argument. `index` is a zero-based index identifying the encoder.
+
+Use `sharpavi:<index>` as argument. `index` is a zero-based index identifying
+the encoder.
 
 You can use `captura-cli list` to check encoder indices.
 
 e.g.
 
-```
+```powershell
 captura-cli start --encoder sharpavi:0
 ```
 
 ## Media Foundation
+
 Use `mf` as argument.
 
 e.g.
 
-```
+```powershell
 captura-cli start --encoder mf
 ```
 
 ### FFmpeg
-Use `ffmpeg:<index>` as argument. `index` is a zero-based index identifying the encoder.
+
+Use `ffmpeg:<index>` as argument. `index` is a zero-based index identifying the
+encoder.
 
 You can use `captura-cli list` to check encoder indices.
 
 e.g.
 
-```
+```powershell
 captura-cli start --encoder ffmpeg:0
 ```
 
 ### Stream
+
 Use `stream:<url>` as argument. `url` is the rtmp url of the streaming service.
 
 e.g. Stream to Twitch
 
-```
+```powershell
 captura-cli start --encoder stream:rtmp://live.twitch.tv/app/TWITCH_KEY
 ```
 
 ### Steps
+
 Use `steps:video` and `steps:images` as `encoder` for Steps recording mode.
 
 #### Record steps to video (avi)
 
-```
+```powershell
 captura-cli start --encoder steps:video
 ```
 
 #### Record steps to a folder containing images (png)
 
-```
+```powershell
 captura-cli start --encoder steps:images
 ```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,31 +1,56 @@
 # Frequently Asked Questions
 
 ## Will Captura support Linux or Mac?
-Captura is written using .NET Framework, which at present, is supported only on Windows.
 
-Software written using .NET Framework can work on Linux and Mac using Mono but the native calls and UI pose a problem to that.
+Captura is written using .NET Framework, which at present, is supported only
+on Windows.
 
-Also, the recently released .Net Core only has support for console applications.
+Software written using .NET Framework can work on Linux and Mac using Mono but
+the native calls and UI pose a problem to that.
+
+Also, the recently released .Net Core only has support for console
+applications.
 
 ## Does Captura support DirectX Game Video Recording?
-Some games can be recorded when running on Windows 8 and above. In Captura v8.0.0 there was a separate `Desktop Duplication` option which can also record games which support that. From v9.0.0, `Desktop Duplication` is the default mode.
+
+Some games can be recorded when running on Windows 8 and above. In Captura
+v8.0.0 there was a separate `Desktop Duplication` option which can also
+record games which support that. From v9.0.0, `Desktop Duplication` is
+the default mode.
 
 ## Why is maximum frame rate 30fps?
-Captura is not very fast on low-end systems. This limit on framerate is a protection against Captura consuming all of your CPU/Memory/Disk and causing your system to hang.
 
-Starting from v8.0.0, you can remove this limitation by going to Config / Extras / Remove FPS Limit.
+Captura is not very fast on low-end systems. This limit on framerate is
+a protection against Captura consuming all of your CPU/Memory/Disk and
+causing your system to hang.
 
-For reference, Captura can capture 1920x1080 screen at 40fps on my system without audio using FFmpeg x264 codec. My system specifications: 8GB RAM DDR4, Intel i5 6th Gen CPU 2.3 GHz, Windows 10.
+Starting from v8.0.0, you can remove this limitation by going to:
+
+1. Config
+2. Extras
+3. Remove FPS Limit.
+
+For reference, Captura can capture 1920x1080 screen at 40fps on my system
+without audio using FFmpeg x264 codec. My system specifications: 8GB RAM
+DDR4, Intel i5 6th Gen CPU 2.3 GHz, Windows 10.
 
 ## Why is the length of captured video shorter than recording duration?
-This happens when Captura drops frames when your system can't keep with the specified frame rate. Try using a lower value of framerate, faster codec or smaller region.
+
+This happens when Captura drops frames when your system can't keep with the
+specified frame rate. Try using a lower value of framerate, faster codec or
+smaller region.
 
 ## Why does Captura run out of resources (high memory/CPU/disk usage) during recording?
+
 Atleast 2 GHz CPU and 4 GB RAM are recommended.
 
-This may happen if frames are not being captured as fast as the framerate set. Try a lower value of framerate, faster codec or smaller region. Also, try terminating unnecessary applications running in background using Task Manager. We admit that the technology employed in Captura is not fast.
+This may happen if frames are not being captured as fast as the framerate set.
+Try a lower value of framerate, faster codec or smaller region. Also, try
+terminating unnecessary applications running in background using Task Manager.
+We admit that the technology employed in Captura is not fast.
 
 ## Why does my Antivirus say that Captura is virus infected?
+
 Captura is virus-free. It does not include any spam, adware or spyware.
 
 It is probably due to the keystrokes capture feature being mistaken for a keylogger.

--- a/docs/FFmpeg.md
+++ b/docs/FFmpeg.md
@@ -1,18 +1,22 @@
 # FFmpeg
 
-> It is recommended to always download the latest version of FFmpeg using FFmpeg Downloader. Older versions of FFmpeg can cause unexpected behaviour.
+> It is recommended to always download the latest version of FFmpeg using
+FFmpeg Downloader. Older versions of FFmpeg can cause unexpected behaviour.
 
-[FFmpeg](http://ffmpeg.org/) is an open-source cross-platform solution to record, convert and stream audio and video.
-It adds support for more output formats like **H.264** for Video and **Mp3**, **AAC** etc. when capturing **Only Audio**.
+[FFmpeg](http://ffmpeg.org/) is an open-source cross-platform solution to
+record, convert and stream audio and video. It adds support for more output
+formats like **H.264** for Video and **Mp3**, **AAC** etc. when capturing
+**Only Audio**.
 
 FFmpeg is configured on the **FFmpeg** section in the **Configure** tab.
 
 Due to its large size (approx. 30MB), it is not included in the downloads.
-If you already have FFmpeg on your system, you can just set the path to the folder containing it.
-If it is installed globally (available in PATH), you don't have to do anything.
-If you don't have FFmpeg or want to update, use the inbuilt **FFmpeg Downloader**.
-FFmpeg needs to be downloaded only once.
+If you already have FFmpeg on your system, you can just set the path to the
+folder containing it. If it is installed globally (available in PATH),
+you don't have to do anything. If you don't have FFmpeg or want to update,
+use the inbuilt **FFmpeg Downloader**. FFmpeg needs to be downloaded only once.
 
-In cases where the **FFmpeg Downloader** fails, please download manually from <https://ffmpeg.zeranoe.com/builds/> and set FFmpeg folder in `Configure | FFmpeg`.
+In cases where the **FFmpeg Downloader** fails, please download manually from
+ <https://ffmpeg.zeranoe.com/builds/> and set FFmpeg folder in `Configure | FFmpeg`.
 
 If you don't want to use FFmpeg, you can switch to `SharpAvi`.

--- a/docs/Portable.md
+++ b/docs/Portable.md
@@ -5,11 +5,11 @@ Starting from v9.0.0, for portable builds:
 1. Settings are stored in `Settings` folder in app folder by default.
    Deleting the `Settings` folder will cause settings to be saved at `%AppData%\Captura`.
    This can be overridden by using the `--settings` command-line argument.
-
 2. FFmpeg is downloaded into `Codecs` folder in app folder by default.
    Deleting the `Codecs` folder will cause FFmpeg to be downloaded into `%LocalAppData%\Captura`.
    This can be overriden from UI.
 
-When setting FFmpeg folder, Settings folder or output folder, `%CAPTURA_PATH%` can be used to refer to the app folder.
+When setting FFmpeg folder, Settings folder or output folder, `%CAPTURA_PATH%`
+can be used to refer to the app folder.
 
 e.g. `%CAPTURA_PATH%/Settings` means `Settings` folder in app folder.

--- a/docs/Projects.md
+++ b/docs/Projects.md
@@ -1,28 +1,41 @@
 # Project Structure
 
 ## Base
-`Captura.Base` contains common interfaces and base classes. This project is referenced by all other projects.
+
+`Captura.Base` contains common interfaces and base classes. This project is
+referenced by all other projects.
 
 ## Localization
+
 `Captura.Loc` contains the localization code.
 
 ## Audio
-`Captura.Audio` contains the audio interfaces which are implemented by specific libraries like `Captura.NAudio`.
+
+`Captura.Audio` contains the audio interfaces which are implemented by specific
+libraries like `Captura.NAudio`.
 
 ## Screna, Core
-`Screna` and `Captura.Core` projects contain the bulk of the code and are depended on by both UI and Console projects.
+
+`Screna` and `Captura.Core` projects contain the bulk of the code and are
+depended on by both UI and Console projects.
 
 ## Windows
+
 `Captura.Windows` conatins code that is completely specific to the Windows OS.
 
 ## Console
+
 `Captura.Console` builds the console application.
 
 ## View Core
-`Captura.ViewCore` project contains View models and is depended on by the UI project.
+
+`Captura.ViewCore` project contains View models and is depended on by the
+UI project.
 
 ## UI
+
 `Captura` is a WPF project containing the UI.
 
 ## Other
+
 The remaining projects add specific features like Imgur, SharpAvi, FFmpeg, etc.

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,3 +1,4 @@
 # Setup
 
-We use [Inno Setup](http://www.jrsoftware.org/isinfo.php) to create the installer for Captura.
+We use [Inno Setup](http://www.jrsoftware.org/isinfo.php) to create the
+installer for Captura.

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -1,30 +1,42 @@
 # System Requirements
+
 System Requirements for the app to run.
 
 ## Operating System
-Windows 10 is recommended.  
-Atleast Windows 7 is required.  
+
+Windows 10 is recommended.
+Atleast Windows 7 is required.
 If you are on Window 7, make sure *Aero* is enabled.
 
-Screen recording is more efficient on Windows 8 and above as compared to Windows 7.
+Screen recording is more efficient on Windows 8 and above as compared to
+Windows 7.
 
 ## Hardware
+
 - 2 GHz CPU (Recommended)
 - 4 GB RAM (Recommended)
 
 ## .NET Framework
-[.NET Framework v4.7.2 Runtime](https://dotnet.microsoft.com/download/dotnet-framework/net472) is required.
+
+[.NET Framework v4.7.2 Runtime](https://dotnet.microsoft.com/download/dotnet-framework/net472)
+is required.
 
 ## FFmpeg
-The app automatically prompts to download FFmpeg if it is not already present on your system.
+
+The app automatically prompts to download FFmpeg if it is not already present
+on your system.
 
 ## Intel QSV
-Using the **FFmpeg Intel QSV HEVC** encoder requires the processor to be **Skylake (6th generation)** or later.
+
+Using the **FFmpeg Intel QSV HEVC** encoder requires the processor to
+be **Skylake (6th generation)** or later.
 
 ## NVenc
+
 See if your GPU supports NVenc for H.264 and H.265 in the [Support Matrix](https://developer.nvidia.com/video-encode-decode-gpu-support-matrix.)
 
 ## Lagarith codec
+
 Lagarith codec can be used with SharpAvi.
 
 - Install the codec from its [official website](https://lags.leetcode.net/codec.html).
@@ -33,6 +45,7 @@ Lagarith codec can be used with SharpAvi.
 
 RGB mode and Null Frames can be configured from the registry:
 
-##### HKEY_CURRENT_USER\Software\Lagarith:
+### HKEY_CURRENT_USER\Software\Lagarith
+
 - Mode = RGB
 - NullFrames= 2294784


### PR DESCRIPTION
Github workflows - Markdown lint tool for documentation.

The lint will fail due to few issues in the documentation MD files. Should I also fix those reported issues or wait for v9.0 documentation to do so?

