### PR TITLE
Add PCM & FLAC as standard audio encoder options for capturing lossless audio

### DIFF
--- a/src/Captura.FFmpeg/Audio/FFmpegAudioItem.cs
+++ b/src/Captura.FFmpeg/Audio/FFmpegAudioItem.cs
@@ -67,12 +67,24 @@ namespace Captura.FFmpeg
                 .AddArg("compression_level", qscale);
         };
 
+        public static FFmpegAudioArgsProvider Pcm { get; } = (Quality, OutputArgs) =>
+        {
+            OutputArgs.SetAudioCodec("copy");
+        };
+
+        public static FFmpegAudioArgsProvider Flac { get; } = (Quality, OutputArgs) =>
+        {
+            OutputArgs.SetAudioCodec("flac");
+        };
+
         public static IEnumerable<FFmpegAudioItem> Items { get; } = new[]
         {
             new FFmpegAudioItem("AAC", ".aac", Aac),
             new FFmpegAudioItem("Mp3", ".mp3", Mp3),
             new FFmpegAudioItem("Vorbis", ".ogg", Vorbis),
-            new FFmpegAudioItem("Opus", ".opus", Opus)
+            new FFmpegAudioItem("Opus", ".opus", Opus),
+            new FFmpegAudioItem("PCM", ".wav", Pcm),
+            new FFmpegAudioItem("FLAC", ".flac", Flac)
         };
     }
 }


### PR DESCRIPTION
Adds "PCM" & "FLAC" options to audio encoder list for custom codecs. PCM & FLAC are both lossless formats.

*Please look over my changes carefully as I currently do not have a C# compiler so I cannot test it*

Related issue: #378

**Edit:** I'm not sure if it would be safer to use "pcm_s16le" instead of "copy" for PCM encoder. On my system pcm_s16le is the native format, so "copy" saves in that format without having to do any re-encoding. I assume that all Windows systems use pcm_s16le natively, but I could be wrong.