### PR TITLE
Avoid flickering when using SharpAvi

### DIFF
--- a/src/Captura.Console/CmdOptions/StartCmdOptions.cs
+++ b/src/Captura.Console/CmdOptions/StartCmdOptions.cs
@@ -54,6 +54,9 @@ namespace Captura
         [Option("settings", HelpText = "Settings file to use for overlay settings, ffmpeg path and output path")]
         public string Settings { get; set; }
 
+        [Option("stop", HelpText = "Token, such as a GUID, to use to stop recording. Can be used with or without length")]
+        public string StopToken { get; set; }
+
         [Usage]
         public static IEnumerable<Example> Examples
         {

--- a/src/Captura.Console/ConsoleManager.cs
+++ b/src/Captura.Console/ConsoleManager.cs
@@ -284,6 +284,22 @@ namespace Captura
 
         void Loop(StartCmdOptions StartOptions)
         {
+            if (!string.IsNullOrEmpty(StartOptions.StopToken))
+            {
+                var waitForSignal = new EventWaitHandle(
+                    false, EventResetMode.ManualReset, StartOptions.StopToken);
+
+                if (StartOptions.Length > 0)
+                {
+                    waitForSignal.WaitOne(StartOptions.Length * 1000);
+                }
+                else
+                {
+                    waitForSignal.WaitOne();
+                }
+                return;
+            }
+
             if (StartOptions.Length > 0)
             {
                 var elapsed = 0;

--- a/src/Captura.SharpAvi/Captura.SharpAvi.csproj
+++ b/src/Captura.SharpAvi/Captura.SharpAvi.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Base\Captura.Base.csproj" />
+    <ProjectReference Include="..\Captura.Windows\Captura.Windows.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SharpAvi" Version="2.1.2" />

--- a/src/Captura.Windows/Native/Msvcrt.cs
+++ b/src/Captura.Windows/Native/Msvcrt.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Captura.Windows.Native
+{
+    public static class Msvcrt
+    {
+        [DllImport("msvcrt.dll", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int memcmp(byte[] b1, byte[] b2, long count);
+    }
+}


### PR DESCRIPTION
When using SharpAvi, frames occasionally get dropped and the Texture2DFrame.CopyTo method produces a transparent frame. This has been observed to happen when recording the Windows desktop applications such as File Explorer. This causes the recording to flicker and have flashes of empty frames.

The fix checks for transparency by comparing the current frame to all zeros, and uses the previously saved frame if necessary. For performance, it uses memcmp to compare to a byte array pre-filled with zeros.

NB: I realize this might be better fixed in the SharpAvi part of the code, but I spent a couple of days investigating and trying out different things, and could not figure out what was causing the frame drops.